### PR TITLE
Fix OSVersion check to include equal versions

### DIFF
--- a/resources/Microsoft.Windows.Developer/Microsoft.Windows.Developer.psm1
+++ b/resources/Microsoft.Windows.Developer/Microsoft.Windows.Developer.psm1
@@ -87,7 +87,7 @@ class OsVersion
     [bool] Test()
     {
         $currentState = $this.Get()
-        return [System.Version]$currentState.OsVersion -gt [System.Version]$currentState.MinVersion
+        return [System.Version]$currentState.OsVersion -ge [System.Version]$currentState.MinVersion
     }
 
     [void] Set()


### PR DESCRIPTION
Fixes the version comparison check to be `greater than or equal to`