### PR TITLE
[Pip3Package]: Fix installed status determined by the last package

### DIFF
--- a/resources/PythonPip3Dsc/PythonPip3Dsc.psm1
+++ b/resources/PythonPip3Dsc/PythonPip3Dsc.psm1
@@ -54,7 +54,7 @@ class Pip3Package
             Arguments = $this.Arguments
             InstalledStatus = $this.InstalledStatus
             InstalledPackages = $this.InstalledPackages
-        }       
+        }
     }
 
     [bool] Test()
@@ -187,7 +187,7 @@ function Invoke-Pip3
 {
     param (
         [Parameter(Mandatory)]
-        [string]$command 
+        [string]$command
     )
 
     if ($global:usePip3Exe)

--- a/resources/PythonPip3Dsc/PythonPip3Dsc.psm1
+++ b/resources/PythonPip3Dsc/PythonPip3Dsc.psm1
@@ -45,6 +45,11 @@ class Pip3Package
         foreach ($package in $this.Packages)
         {
             $this.InstalledStatus = $this.InstalledPackages -contains $package
+
+            if ($this.InstalledStatus -eq $false)
+            {
+                break
+            }
         }
 
         return @{


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-dsc).
- [x] This pull request is related to an issue.
   - Resolves #46


Break the loop if we find a non-installed package and return InstalledStatus as false

-----
