### PR TITLE
Use uninstall registry to determine VScode install location

### DIFF
--- a/resources/Microsoft.VSCode.Dsc/Microsoft.VSCode.Dsc.psm1
+++ b/resources/Microsoft.VSCode.Dsc/Microsoft.VSCode.Dsc.psm1
@@ -10,6 +10,14 @@ function Get-VSCodeCLIPath {
         [switch]$Insiders
     )
 
+    # Product Codes for VSCode and VSCode Insider:
+    $vsCodeUserProductCode = "{771FD6B0-FA20-440A-A002-3B3BAC16DC50}_is1"
+    $vsCodeMachineProductCode = "{EA457B21-F73E-494C-ACAB-524FDE069978}_is1"
+
+    $vsCodeInsidersUserProductCode = "{217B4C08-948D-4276-BFBB-BEE930AE5A2C}_is1"
+    $vsCodeInsidersMachineProductCode = "{1287CAD5-7C8D-410D-88B9-0D1EE4A83FF2}_is1"
+
+    # Note: WOW6432 registry not checked as no uninstall entry was found.
     $userUninstallRegistry = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall"
     $machineUninstallRegistry = "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall"
     $installLocationProperty = "InstallLocation"
@@ -17,13 +25,13 @@ function Get-VSCodeCLIPath {
     if ($Insiders)
     {
         $cmdPath = "bin\code-insiders.cmd"
-        $insidersUserInstallLocation = TryGetRegistryValue -Key "$($userUninstallRegistry)\{217B4C08-948D-4276-BFBB-BEE930AE5A2C}_is1" -Property $installLocationProperty
+        $insidersUserInstallLocation = TryGetRegistryValue -Key "$($userUninstallRegistry)\$($vsCodeInsidersUserProductCode)" -Property $installLocationProperty
         if ($insidersUserInstallLocation)
         {
             return $insidersUserInstallLocation + $cmdPath
         }
 
-        $insidersMachineInstallLocation = TryGetRegistryValue -Key "$($machineUninstallRegistry)\{1287CAD5-7C8D-410D-88B9-0D1EE4A83FF2}_is1" -Property $installLocationProperty
+        $insidersMachineInstallLocation = TryGetRegistryValue -Key "$($machineUninstallRegistry)\$($vsCodeInsidersMachineProductCode)" -Property $installLocationProperty
         if ($insidersMachineInstallLocation)
         {
             return $insidersMachineInstallLocation + $cmdPath
@@ -32,13 +40,13 @@ function Get-VSCodeCLIPath {
     else
     {
         $cmdPath = "bin\code.cmd"
-        $codeUserInstallLocation = TryGetRegistryValue -Key "$($userUninstallRegistry)\{771FD6B0-FA20-440A-A002-3B3BAC16DC50}_is1" -Property $installLocationProperty
+        $codeUserInstallLocation = TryGetRegistryValue -Key "$($userUninstallRegistry)\$($vsCodeUserProductCode)" -Property $installLocationProperty
         if ($codeUserInstallLocation)
         {
             return $codeUserInstallLocation + $cmdPath
         }
 
-        $codeMachineInstallLocation = TryGetRegistryValue -Key "$($machineUninstallRegistry)\{EA457B21-F73E-494C-ACAB-524FDE069978}_is1" -Property $installLocationProperty
+        $codeMachineInstallLocation = TryGetRegistryValue -Key "$($machineUninstallRegistry)\$($vsCodeMachineProductCode)" -Property $installLocationProperty
         if ($codeMachineInstallLocation)
         {
             return $codeMachineInstallLocation + $cmdPath

--- a/resources/Microsoft.VSCode.Dsc/Microsoft.VSCode.Dsc.psm1
+++ b/resources/Microsoft.VSCode.Dsc/Microsoft.VSCode.Dsc.psm1
@@ -10,16 +10,20 @@ function Get-VSCodeCLIPath {
         [switch]$Insiders
     )
 
+    $userUninstallRegistry = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall"
+    $machineUninstallRegistry = "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall"
+    $installLocationProperty = "InstallLocation"
+
     if ($Insiders)
     {
         $cmdPath = "bin\code-insiders.cmd"
-        $insidersUserInstallLocation = TryGetRegistryValue -Key "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\{217B4C08-948D-4276-BFBB-BEE930AE5A2C}_is1" -Property "InstallLocation"
+        $insidersUserInstallLocation = TryGetRegistryValue -Key "$($userUninstallRegistry)\{217B4C08-948D-4276-BFBB-BEE930AE5A2C}_is1" -Property $installLocationProperty
         if ($insidersUserInstallLocation)
         {
             return $insidersUserInstallLocation + $cmdPath
         }
 
-        $insidersMachineInstallLocation = TryGetRegistryValue -Key "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\{1287CAD5-7C8D-410D-88B9-0D1EE4A83FF2}_is1" -Property "InstallLocation"
+        $insidersMachineInstallLocation = TryGetRegistryValue -Key "$($machineUninstallRegistry)\{1287CAD5-7C8D-410D-88B9-0D1EE4A83FF2}_is1" -Property $installLocationProperty
         if ($insidersMachineInstallLocation)
         {
             return $insidersMachineInstallLocation + $cmdPath
@@ -28,13 +32,13 @@ function Get-VSCodeCLIPath {
     else
     {
         $cmdPath = "bin\code.cmd"
-        $codeUserInstallLocation = TryGetRegistryValue -Key "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\{771FD6B0-FA20-440A-A002-3B3BAC16DC50}_is1" -Property "InstallLocation"
+        $codeUserInstallLocation = TryGetRegistryValue -Key "$($userUninstallRegistry)\{771FD6B0-FA20-440A-A002-3B3BAC16DC50}_is1" -Property $installLocationProperty
         if ($codeUserInstallLocation)
         {
             return $codeUserInstallLocation + $cmdPath
         }
 
-        $codeMachineInstallLocation = TryGetRegistryValue -Key "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\{EA457B21-F73E-494C-ACAB-524FDE069978}_is1" -Property "InstallLocation"
+        $codeMachineInstallLocation = TryGetRegistryValue -Key "$($machineUninstallRegistry)\{EA457B21-F73E-494C-ACAB-524FDE069978}_is1" -Property $installLocationProperty
         if ($codeMachineInstallLocation)
         {
             return $codeMachineInstallLocation + $cmdPath
@@ -97,8 +101,6 @@ function Invoke-VSCode {
         throw ("Executing {0} with {$Command} failed." -f $VSCodeCLIPath)
     }
 }
-
-
 
 function TryGetRegistryValue{
     param (

--- a/tests/Microsoft.VSCode.Dsc/Microsoft.VSCode.Dsc.Tests.ps1
+++ b/tests/Microsoft.VSCode.Dsc/Microsoft.VSCode.Dsc.Tests.ps1
@@ -66,7 +66,7 @@ Describe 'VSCodeExtension-Insiders' {
     It 'Keeps current extension in Insiders edition.' -Skip:(!$IsWindows) {
         $parameters = @{
             Name = 'ms-vscode.powershell'
-            UseInsiders = $true
+            Insiders = $true
         }
 
         $initialState = Invoke-DscResource -Name VSCodeExtension -ModuleName Microsoft.VSCode.Dsc -Method Get -Property $parameters
@@ -85,7 +85,7 @@ Describe 'VSCodeExtension-Insiders' {
     It 'Sets desired extension in Insiders edition' -Skip:(!$IsWindows) {
         $desiredState = @{
             Name = 'ms-azure-devops.azure-pipelines'
-            UseInsiders = $true
+            Insiders = $true
         }
         
         Invoke-DscResource -Name VSCodeExtension -ModuleName Microsoft.VSCode.Dsc -Method Set -Property $desiredState


### PR DESCRIPTION
Resolves #61

VSCode and Insiders have specific product codes in the uninstall registry. I check the value for install location to determine where to find the cmd path. This should resolve issues with custom install paths.