### PR TITLE
Try and fix Project-File Label

### DIFF
--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -71,15 +71,15 @@ configuration:
                 pattern: ^$
           - or:
               - filesMatchPattern:
-                  pattern: ^.github\\.*
+                  pattern: ^\.?[\\\/]?.github[\\\/].*
               - filesMatchPattern:
-                  pattern: ^.configurations\\.*
+                  pattern: ^\.?[\\\/]?.configurations[\\\/].*
               - filesMatchPattern:
-                  pattern: ^.vscode\\.*
+                  pattern: ^\.?[\\\/]?.vscode[\\\/].*
               - filesMatchPattern:
-                  pattern: ^doc\\.*
+                  pattern: ^\.?[\\\/]?doc[\\\/].*
               - filesMatchPattern:
-                  pattern: ^Tools\\.*
+                  pattern: ^\.?[\\\/]?Tools[\\\/].*
               - filesMatchPattern:
                   pattern: ^.*\.md$
               - filesMatchPattern:


### PR DESCRIPTION
The label isn't being applied when in directories for some reason. Updates the regex to use either forward or backslash as the directory separator, and allows for a leading . specifier just in case

cc @denelon
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-dsc/pull/118)