### PR TITLE
Copy `sampleConfigurations` folder from devhome repo to a `sample` folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DSC Resources for WinGet Configuration
 
-This project is intended to support WinGet Configuration. Some of these Desired State Configuration (DSC) Resources are exploratory and may not be published in the PowerShell Gallery. Other resources may be moved to their own projects or removed entirely.  [Samples](https://aka.ms/dsc.yaml) for using these resources are available in the [Dev Home](https://github.com/microsoft/devhome) repository.
+This project is intended to support WinGet Configuration. Some of these Desired State Configuration (DSC) Resources are exploratory and may not be published in the PowerShell Gallery. Other resources may be moved to their own projects or removed entirely. Samples for using these resources are available in the [samples](./samples/) directory. They are also available via the URL: `https://aka.ms/dsc.yaml`
 
 ## Contributing
 

--- a/samples/DscResources/GitDsc/CloneWingetRepository.yaml
+++ b/samples/DscResources/GitDsc/CloneWingetRepository.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+
+########################################################################################
+# This configuration will clone the winget-cli repository to a specified location.     #
+# PowerShell module: GitDsc (v0.1.3-alpha)                                             #
+########################################################################################
+
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
+        description: Install Git
+        allowPrerelease: true
+      settings:
+        id: Git.Git
+        source: winget
+    - resource: GitDsc/GitClone
+      directives:
+        description: Clone the winget-cli repository
+        allowPrerelease: true
+      settings:
+        HttpsUrl: https://github.com/microsoft/winget-cli.git
+        RootDirectory: '${WingetConfigRoot}/SampleRepos/'
+    # - resource: GitDsc/GitRemote
+    #   directives:
+    #     description: Add a remote repository to the cloned winget-cli repository.
+    #     allowPrerelease: true
+    #   settings:
+    #     RemoteName: exampleName
+    #     RemoteUrl: https://github.com/exampleName/winget-cli.git
+    #     ProjectDirectory: '${WingetConfigRoot}/SampleRepos/winget-cli'
+  configurationVersion: 0.2.0

--- a/samples/DscResources/Microsoft.Windows.Developer/ModifyWindowsSettings.yaml
+++ b/samples/DscResources/Microsoft.Windows.Developer/ModifyWindowsSettings.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+
+###########################################################################
+# This configuration will modify various Windows Settings.                #
+# PowerShell module: Microsoft.Windows.Developer (v0.2.1-alpha)           #
+###########################################################################
+
+properties:
+  resources:
+    - resource: Microsoft.Windows.Developer/Taskbar
+      directives:
+        description: Modify taskbar settings
+        allowPrerelease: true
+      settings:
+        Alignment: Left # [KeepCurrentValue, Middle]
+        HideLabelsMode: Never # [KeepCurrentValue, WhenFull, Always]
+        SearchBoxMode: ShowIconAndLabel # [KeepCurrentValue, ShowIconOnly, SearchBox, Hide]
+        TaskViewButton: Show # [KeepCurrentValue, Hide]
+        WidgetsButton: Show # [KeepCurrentValue, Hide]
+        RestartExplorer: True # Use caution when setting `RestartExplorer: true` as this will force explorer to close. Required for `HideLabelsMode`.
+    - resource: Microsoft.Windows.Developer/WindowsExplorer
+      directives:
+        description: Modify Windows Explorer settings
+        allowPrerelease: true
+      settings:
+        FileExtensions: Hide # [KeepCurrentValue, Hide]
+        HiddenFiles: Hide # [KeepCurrentValue, Hide]
+        ItemCheckBoxes: Hide # [KeepCurrentValue, Hide]
+        RestartExplorer: True # Use caution when setting `RestartExplorer: true` as this will force explorer to close. Required for all WindowsExplorer settings.
+    - resource: Microsoft.Windows.Developer/ShowSecondsInClock
+      directives:
+        description: Show seconds in clock
+        allowPrerelease: true
+      settings:
+        Ensure: Present
+    - resource: Microsoft.Windows.Developer/EnableDarkMode
+      directives:
+        description: Disable dark mode
+        allowPrerelease: true
+      settings:
+        Ensure: Absent
+        # Use caution when setting `RestartExplorer: true` as this will force explorer to close.
+        RestartExplorer: true # Required to apply changes
+  configurationVersion: 0.2.0

--- a/samples/DscResources/Microsoft.Windows.Developer/RevertWindowsSettings.yaml
+++ b/samples/DscResources/Microsoft.Windows.Developer/RevertWindowsSettings.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+
+###########################################################################
+# This configuration will revert various Windows Settings.                #
+# PowerShell module: Microsoft.Windows.Developer (v0.2.1-alpha)           #
+###########################################################################
+
+properties:
+  resources:
+    - resource: Microsoft.Windows.Developer/Taskbar
+      directives:
+        description: Revert taskbar settings
+        allowPrerelease: true
+      settings:
+        Alignment: Middle # [KeepCurrentValue, Left]
+        HideLabelsMode: Always # [KeepCurrentValue, WhenFull, Never]
+        SearchBoxMode: Hide # [KeepCurrentValue, ShowIconOnly, SearchBox, ShowIconAndLabel]
+        TaskViewButton: Hide # [KeepCurrentValue, Show]
+        WidgetsButton: Hide # [KeepCurrentValue, Show]
+        RestartExplorer: True # Use caution when setting `RestartExplorer: true` as this will force explorer to close. Required for `HideLabelsMode`.
+    - resource: Microsoft.Windows.Developer/WindowsExplorer
+      directives:
+        description: Revert Windows Explorer settings
+        allowPrerelease: true
+      settings:
+        FileExtensions: Show # [KeepCurrentValue, Hide]
+        HiddenFiles: Show # [KeepCurrentValue, Hide]
+        ItemCheckBoxes: Show # [KeepCurrentValue, Hide]
+        RestartExplorer: # Use caution when setting `RestartExplorer: true` as this will force explorer to close. Required for all WindowsExplorer settings.
+    - resource: Microsoft.Windows.Developer/ShowSecondsInClock
+      directives:
+        description: Hide seconds in clock
+        allowPrerelease: true
+      settings:
+        Ensure: Absent
+    - resource: Microsoft.Windows.Developer/EnableDarkMode
+      directives:
+        description: Enable dark mode
+        allowPrerelease: true
+      settings:
+        Ensure: Present
+        # Use caution when setting `RestartExplorer: true` as this will force explorer to close.
+        RestartExplorer: true # Required to apply changes
+  configurationVersion: 0.2.0

--- a/samples/DscResources/Microsoft.WindowsSandbox.DSC/README.md
+++ b/samples/DscResources/Microsoft.WindowsSandbox.DSC/README.md
@@ -1,0 +1,38 @@
+# Microsoft.WindowsSandbox.DSC
+The [Microsoft.WindowsSandbox.DSC](https://www.powershellgallery.com/packages/Microsoft.WindowsSandbox.DSC) PowerShell module contains the WindowsSandbox DSC Resource. This resource accepts either a reference to a Windows Sandbox .WSB file or properties to configure and launch an instance of the Windows Sandbox.
+
+>Note: The Windows Sandbox is an ephemoral instance of Windows. It also defaults to an administrative context when running the LogonCommand.
+
+Prior to running this configuration, users should be on either Windows PRO or Windows enterprise. The "Windows Sandbox" optional feature also needs to be enabled.
+
+The "full.sandbox.dsc.yaml" configuration is not fully capable of verifying the Windows SKU or enabling Windows optional features via the WinGet CLI (and subsequently Dev Home). The Windows optional features can be enabled in a configuration when run via the Microsoft.WinGet.Configuration.
+
+The "full.sandbox.dsc.yaml" configuration can be run via the Microsoft.WinGet.Configuration module.
+
+Install the module using:
+```PowerShell
+Install-Module -Name Microsoft.WindowsSandbox.DSC -AllowPrerelease
+```
+
+Run the configuration in PowerShell 7 using:
+```PowerShell
+get-WinGetConfiguration -File full.sandbox.dsc.yaml | Invoke-WinGetConfiguration
+```
+
+## How to use the WinGet Configuration File
+The following two options are available for running a WinGet Configuration file on your device. 
+
+### 1. Windows Package Manager
+1. Download the `sandbox.dsc.yaml` file to your computer.
+1. Open your Windows Start Menu, search and launch "*Windows Terminal*".
+1. Type the following: `CD <C:\Users\User\Download>`
+1. Type the following: `winget configure --file .\sandbox.dsc.yaml`
+
+### 2. Dev Home
+1. Download the `sandbox.dsc.yaml` file to your computer.
+1. Open your Windows Start Menu, search and launch "*Dev Home*".
+1. Select the *Machine Configuration* button on the left side navigation.
+1. Select the *Configuration file* button
+1. Locate and open the WinGet Configuration file downloaded in "step 1".
+1. Select the "I agree and want to continue" checkbox.
+1. Select the "Set up as admin" button.

--- a/samples/DscResources/Microsoft.WindowsSandbox.DSC/README.md
+++ b/samples/DscResources/Microsoft.WindowsSandbox.DSC/README.md
@@ -1,4 +1,5 @@
 # Microsoft.WindowsSandbox.DSC
+
 The [Microsoft.WindowsSandbox.DSC](https://www.powershellgallery.com/packages/Microsoft.WindowsSandbox.DSC) PowerShell module contains the WindowsSandbox DSC Resource. This resource accepts either a reference to a Windows Sandbox .WSB file or properties to configure and launch an instance of the Windows Sandbox.
 
 >Note: The Windows Sandbox is an ephemoral instance of Windows. It also defaults to an administrative context when running the LogonCommand.
@@ -10,25 +11,30 @@ The "full.sandbox.dsc.yaml" configuration is not fully capable of verifying the 
 The "full.sandbox.dsc.yaml" configuration can be run via the Microsoft.WinGet.Configuration module.
 
 Install the module using:
+
 ```PowerShell
 Install-Module -Name Microsoft.WindowsSandbox.DSC -AllowPrerelease
 ```
 
 Run the configuration in PowerShell 7 using:
+
 ```PowerShell
 get-WinGetConfiguration -File full.sandbox.dsc.yaml | Invoke-WinGetConfiguration
 ```
 
 ## How to use the WinGet Configuration File
-The following two options are available for running a WinGet Configuration file on your device. 
+
+The following two options are available for running a WinGet Configuration file on your device.
 
 ### 1. Windows Package Manager
+
 1. Download the `sandbox.dsc.yaml` file to your computer.
 1. Open your Windows Start Menu, search and launch "*Windows Terminal*".
 1. Type the following: `CD <C:\Users\User\Download>`
 1. Type the following: `winget configure --file .\sandbox.dsc.yaml`
 
 ### 2. Dev Home
+
 1. Download the `sandbox.dsc.yaml` file to your computer.
 1. Open your Windows Start Menu, search and launch "*Dev Home*".
 1. Select the *Machine Configuration* button on the left side navigation.

--- a/samples/DscResources/Microsoft.WindowsSandbox.DSC/full.sandbox.dsc.yaml
+++ b/samples/DscResources/Microsoft.WindowsSandbox.DSC/full.sandbox.dsc.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+
+###############################################################################
+# Create Windows Sandbox instance with WinGet installed.                      #
+# Run as Administrator                                                        #
+# Mount C:\Sandbox on the local filesystem into the Sandbox filesystem.       #
+# The Logon command performs the following steps in Windows PowerShell:       #
+# 1. Set the execution policy to RemoteSigned                                 #
+# 2. Download and install App Installer (WinGet) and it's dependencies        #
+############################################################################### 
+
+properties:
+  resources:
+    - resource: PSDscResources/WindowsOptionalFeature
+      id: WindowsSandbox
+      directives:
+        description: Ensure Windows Sandbox is enabled
+      settings:
+        Name: Containers-DisposableClientVM
+        Ensure: Present
+    - resource: Microsoft.WindowsSandbox.DSC/WindowsSandbox
+      dependsOn: 
+        - WindowsSandbox
+      directives:
+        description: Create Windows Sandbox with Winget installed
+        allowPrerelease: true
+      settings:
+        Ensure: Present        
+        HostFolder: C:\Sandbox
+        SandboxFolder: C:\Sandbox
+        LogonCommand: >
+          cmd /c start powershell -NoExit -Command "$progressPreference = 'silentlyContinue';
+          Write-Host 'Setting execution policy to remote signed...' `n;
+          Set-ExecutionPolicy RemoteSigned -Force;
+          Write-Host 'Downloading WinGet and its dependencies...' `n;
+          Invoke-WebRequest -Uri https://aka.ms/getwinget -OutFile Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle;
+          Invoke-WebRequest -Uri https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx;
+          Invoke-WebRequest -Uri https://github.com/microsoft/microsoft-ui-xaml/releases/download/v2.8.6/Microsoft.UI.Xaml.2.8.x64.appx -OutFile Microsoft.UI.Xaml.2.8.x64.appx;
+          Add-AppxPackage Microsoft.VCLibs.x64.14.00.Desktop.appx;
+          Add-AppxPackage Microsoft.UI.Xaml.2.8.x64.appx;
+          Add-AppxPackage Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle;
+  configurationVersion: 0.2.0

--- a/samples/DscResources/Microsoft.WindowsSandbox.DSC/sandbox.dsc.yaml
+++ b/samples/DscResources/Microsoft.WindowsSandbox.DSC/sandbox.dsc.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+
+###############################################################################
+# Create Windows Sandbox instance with WinGet installed.                      #
+# Run as Administrator                                                        #
+# Mount C:\Sandbox on the local filesystem into the Sandbox filesystem.       #
+# The Logon command performs the following steps in Windows PowerShell:       #
+# 1. Set the execution policy to RemoteSigned                                 #
+# 2. Download and install App Installer (WinGet) and it's dependencies        #
+############################################################################### 
+
+properties:
+  resources:
+    - resource: Microsoft.WindowsSandbox.DSC/WindowsSandbox
+      directives:
+        description: Create Windows Sandbox with Winget installed
+        allowPrerelease: true
+      settings:
+        Ensure: Present
+        #WsbFile: <Provide a custom .wsb file to open. The parameters below will override existing values in the wsb file>
+        LogonCommand: >
+          cmd /c start powershell -NoExit -Command "$progressPreference = 'silentlyContinue';
+          Write-Host 'Setting execution policy to remote signed...' `n;
+          Set-ExecutionPolicy RemoteSigned -Force;
+          Write-Host 'Downloading WinGet and its dependencies...' `n;
+          Invoke-WebRequest -Uri https://aka.ms/getwinget -OutFile Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle;
+          Invoke-WebRequest -Uri https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx;
+          Invoke-WebRequest -Uri https://github.com/microsoft/microsoft-ui-xaml/releases/download/v2.8.6/Microsoft.UI.Xaml.2.8.x64.appx -OutFile Microsoft.UI.Xaml.2.8.x64.appx;
+          Add-AppxPackage Microsoft.VCLibs.x64.14.00.Desktop.appx;
+          Add-AppxPackage Microsoft.UI.Xaml.2.8.x64.appx;
+          Add-AppxPackage Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle;
+        #HostFolder: <Absolute path to folder on host machine that will be shared into the Windows Sandbox>
+        #SandboxFolder: <Absolute path to destination in the sandbox to map the Host Folder to>
+        #ReadOnly: false
+        #MemoryInMB: 2048
+        #vGPU: true
+        #AudioInput: true
+        #ClipboardRedirection: true
+        #Networking: true
+        #PrinterRedirection: false
+        #ProtectedClient: false
+        #VideoInput: true
+  configurationVersion: 0.2.0

--- a/samples/DscResources/PowerToysConfigure/PowerToys.dsc.yaml
+++ b/samples/DscResources/PowerToysConfigure/PowerToys.dsc.yaml
@@ -1,0 +1,29 @@
+################################################################################
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2    #
+#                                                                              #
+# This DSC config file will install Microsoft.PowerToys, then configure, by:   #
+# Disabling the ShortcutGuide and setting it to full opacity, then enabling    #
+# Fancy Zones and setting the Fancy Zone Editor hotkey to Shift+Ctrl+Alt+F.    #
+#                                                                              #
+################################################################################
+#
+properties:
+  configurationVersion: 0.2.0
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
+        description: Install PowerToys
+        allowPrerelease: true
+      settings:
+        id: Microsoft.PowerToys
+        source: winget
+    - resource: PowerToysConfigure
+      directives:
+        description: Configure PowerToys
+      settings:
+        ShortcutGuide:
+          Enabled: false
+          OverlayOpacity: 1
+        FancyZones:
+          Enabled: true
+          FancyzonesEditorHotkey: "Shift+Ctrl+Alt+F"

--- a/samples/DscResources/README.md
+++ b/samples/DscResources/README.md
@@ -1,0 +1,18 @@
+## Sample Configurations for Specific DSC Resources
+
+The sample configurations provided in this directory showcase how to create WinGet configuration files utilizing DSC resources for more specific scenarios.
+
+### [GitDsc](https://www.powershellgallery.com/packages/GitDsc/0.1.2-alpha)
+
+Supports cloning a new repository and adding/removing remote connections to other repositories.
+
+### [Microsoft.WindowsSandbox.DSC](https://www.powershellgallery.com/packages/Microsoft.WindowsSandbox.DSC/0.1.1-alpha)
+
+Create a new instance of Windows Sandbox by either providing a custom .wsb file or specifying parameters.
+
+>Note: [Windows Sandbox](https://learn.microsoft.com/windows/security/application-security/application-isolation/windows-sandbox/windows-sandbox-overview#prerequisites) requires Windows 10 Pro or Enterprise, build version 18305 or Windows 11.
+
+### [Microsoft.Windows.Developer](https://www.powershellgallery.com/packages/Microsoft.Windows.Developer/0.1.3-alpha)
+
+Modify various Windows Settings such as showing seconds in clock, hiding file extensions, or showing the task view button...
+

--- a/samples/DscResources/README.md
+++ b/samples/DscResources/README.md
@@ -15,4 +15,3 @@ Create a new instance of Windows Sandbox by either providing a custom .wsb file 
 ### [Microsoft.Windows.Developer](https://www.powershellgallery.com/packages/Microsoft.Windows.Developer/0.1.3-alpha)
 
 Modify various Windows Settings such as showing seconds in clock, hiding file extensions, or showing the task view button...
-

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,28 @@
+## Using the sample configurations
+Download the *.dsc.yaml files to your local system. They can be executed in Dev Home via the "Machine configuration" section. They can also be executed by running `winget configure <path to configuration file>`.
+
+Several DSC resources may require running in administrator mode. If the configuration is leveraging the [WinGet DSC resource](https://www.powershellgallery.com/packages/Microsoft.WinGet.DSC) to install packages, there are also limitations in some cases specific to the installers that may either require or prohibit installation in administrative context.
+
+### GitHub projects (Repositories)
+Sample configurations have been provided for various GitHub repositories. These configurations ideally should be placed in a `.configurations` folder in the root of the project directory. Some DSC resources may have parameters that allow you to pass in a relative file path. The reserved variable `$(WinGetConfigRoot)` can be used to specify the full path of the configuration file. An example of how to use that variable with a relative file path is shown below:
+
+```yaml
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      dependsOn:
+      directives:
+        description: Install required VS workloads from .vsconfig file
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Community
+        channelId: VisualStudio.17.Release
+        vsConfigFile: '${WinGetConfigRoot}\..\.vsconfig'
+```
+
+### Learn to Code (Templates)
+Sample configurations in this directory are directly related to the [Windows development paths](https://learn.microsoft.com/windows/dev-environment/#development-paths). These configurations will allow you to automatically set up your device and begin developing in your preferred language quickly.
+
+### Sample DSC Resources (DscResources)
+Examples for a few specific DSC Resources are under the [DscResources](./DscResources/) directory.
+
+### Create your own
+Writing YAML is a pain. To help you get started creating your own, there is a [sample tool](https://github.com/microsoft/winget-create/blob/main/Tools/WingetCreateMakeDSC.ps1) for authoring in the winget-create repo. It currently only supports adding apps, but give it a try and contribute to make it better!

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,9 +1,13 @@
+# DSC Samples
+
 ## Using the sample configurations
+
 Download the *.dsc.yaml files to your local system. They can be executed in Dev Home via the "Machine configuration" section. They can also be executed by running `winget configure <path to configuration file>`.
 
 Several DSC resources may require running in administrator mode. If the configuration is leveraging the [WinGet DSC resource](https://www.powershellgallery.com/packages/Microsoft.WinGet.DSC) to install packages, there are also limitations in some cases specific to the installers that may either require or prohibit installation in administrative context.
 
 ### GitHub projects (Repositories)
+
 Sample configurations have been provided for various GitHub repositories. These configurations ideally should be placed in a `.configurations` folder in the root of the project directory. Some DSC resources may have parameters that allow you to pass in a relative file path. The reserved variable `$(WinGetConfigRoot)` can be used to specify the full path of the configuration file. An example of how to use that variable with a relative file path is shown below:
 
 ```yaml
@@ -19,10 +23,13 @@ Sample configurations have been provided for various GitHub repositories. These 
 ```
 
 ### Learn to Code (Templates)
+
 Sample configurations in this directory are directly related to the [Windows development paths](https://learn.microsoft.com/windows/dev-environment/#development-paths). These configurations will allow you to automatically set up your device and begin developing in your preferred language quickly.
 
 ### Sample DSC Resources (DscResources)
+
 Examples for a few specific DSC Resources are under the [DscResources](./DscResources/) directory.
 
 ### Create your own
+
 Writing YAML is a pain. To help you get started creating your own, there is a [sample tool](https://github.com/microsoft/winget-create/blob/main/Tools/WingetCreateMakeDSC.ps1) for authoring in the winget-create repo. It currently only supports adding apps, but give it a try and contribute to make it better!

--- a/samples/Repositories/PowerShell/PowerShell/configuration.dsc.yaml
+++ b/samples/Repositories/PowerShell/PowerShell/configuration.dsc.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/PowerShell/PowerShell/blob/master/docs/building/windows-core.md
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
+        description: Install Visual Studio 2022 Community
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudio.2022.Community
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
+        description: Install .NET SDK 8.0-preview
+        allowPrerelease: true
+      settings:
+        id: Microsoft.DotNet.SDK.Preview
+        source: winget
+  configurationVersion: 0.2.0

--- a/samples/Repositories/Windows/dev-environment/javascript/nodejs-on-windows/NodeJS.dsc.yaml
+++ b/samples/Repositories/Windows/dev-environment/javascript/nodejs-on-windows/NodeJS.dsc.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+
+
+##########################################################################################################
+# This configuration will install the tools necessary to get started with Node.js development on Windows #
+# Reference: https://learn.microsoft.com/windows/dev-environment/javascript/nodejs-on-windows            #
+#                                                                                                        #
+# Note: If an existing version of Node.js is installed on the machine outside of NVM, you will be        #
+#       prompted to either allow NVM to manage that installation or remove it.                           #
+##########################################################################################################
+
+
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: Git
+      directives:
+        description: Install Git
+        allowPrerelease: true
+      settings:
+        id: Git.Git
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: VSCode
+      directives:
+        description: Install Visual Studio Code
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudioCode
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: NVM
+      directives:
+        description: Install NVM for Windows
+        allowPrerelease: true
+      settings:
+        id: CoreyButler.NVMforWindows
+        source: winget
+  configurationVersion: 0.2.0

--- a/samples/Repositories/apache/echarts/configuration.dsc.yaml
+++ b/samples/Repositories/apache/echarts/configuration.dsc.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/apache/echarts#build
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: npm
+      directives:
+        description: Install Node.js
+        allowPrerelease: true
+      settings:
+        id: OpenJS.NodeJS
+        source: winget
+    - resource: NpmDsc/NpmInstall
+      dependsOn:
+        - npm
+      directives:
+        description: Run 'npm install'
+        allowPrerelease: true
+      settings:
+        PackageDirectory: '${WinGetConfigRoot}\..\' 
+  configurationVersion: 0.2.0

--- a/samples/Repositories/apache/echarts/configuration.dsc.yaml
+++ b/samples/Repositories/apache/echarts/configuration.dsc.yaml
@@ -17,5 +17,5 @@ properties:
         description: Run 'npm install'
         allowPrerelease: true
       settings:
-        PackageDirectory: '${WinGetConfigRoot}\..\' 
+        PackageDirectory: '${WinGetConfigRoot}\..\'
   configurationVersion: 0.2.0

--- a/samples/Repositories/dotnet/aspnetcore/configuration.dsc.yaml
+++ b/samples/Repositories/dotnet/aspnetcore/configuration.dsc.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/dotnet/aspnetcore/blob/main/docs/BuildFromSource.md
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
+        description: Install Microsoft Open JDK 17
+        allowPrerelease: true
+      settings:
+        id: Microsoft.OpenJDK.17
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
+        description: Install Yarn
+        allowPrerelease: true
+      settings:
+        id: Yarn.Yarn
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
+        description: Install Node.js
+        allowPrerelease: true
+      settings:
+        id: OpenJS.NodeJS
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: vsPackage
+      directives:
+        description: Install Visual Studio 2022 Community
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudio.2022.Community
+        source: winget
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      dependsOn:
+        - vsPackage
+      directives:
+        description: Install required VS workloads
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Community
+        channelId: VisualStudio.17.Release
+        vsConfigFile: '${WinGetConfigRoot}\..\.vsconfig'
+  configurationVersion: 0.2.0

--- a/samples/Repositories/jquery/jquery/configuration.dsc.yaml
+++ b/samples/Repositories/jquery/jquery/configuration.dsc.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/jquery/jquery#how-to-build-your-own-jquery
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: npm
+      directives:
+        description: Install Node version 8+
+        allowPrerelease: true
+      settings:
+        id: OpenJS.NodeJS
+        source: winget
+    - resource: NpmDsc/NpmInstall
+      directives:
+        description: Install all package dependencies
+        allowPrerelease: true
+      settings:
+        Ensure: 'Present'
+        PackageDirectory: '${WinGetConfigRoot}\..\'
+    - resource: NpmDsc/NpmPackage
+      directives:
+        description: Install grunt-cli globally
+        allowPrerelease: true
+      settings:
+        Name: 'grunt-cli'
+        Global: true
+        Ensure: 'Present'
+        PackageDirectory: '${WinGetConfigRoot}\..\'
+  configurationVersion: 0.2.0

--- a/samples/Repositories/microsoft/PowerToys/configuration.dsc.yaml
+++ b/samples/Repositories/microsoft/PowerToys/configuration.dsc.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/microsoft/PowerToys/blob/main/doc/devdocs/readme.md#compiling-powertoys
+properties:
+  resources:
+    - resource: Microsoft.Windows.Developer/DeveloperMode
+      directives:
+        description: Enable Developer Mode
+        allowPrerelease: true
+      settings:
+        Ensure: Present
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: vsPackage
+      directives:
+        description: Install Visual Studio 2022 (any edition is OK)
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudio.2022.Community
+        source: winget
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      dependsOn:
+        - vsPackage
+      directives:
+        description: Install required VS workloads
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Community
+        channelId: VisualStudio.17.Release
+        vsConfigFile: '${WinGetConfigRoot}\..\.vsconfig'
+  configurationVersion: 0.2.0
+
+  # Next steps:
+  # Open a terminal
+  # Navigate to the folder you cloned PowerToys to.
+  # Run git submodule update --init --recursive

--- a/samples/Repositories/microsoft/gdk/configuration.dsc.yaml
+++ b/samples/Repositories/microsoft/gdk/configuration.dsc.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: vsPackage
+      directives:
+        description: Install Visual Studio 2022 Community
+        module: Microsoft.WinGet.DSC
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudio.2022.Community
+        source: winget
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      id: vsConfig
+      dependsOn:
+        - vsPackage
+      directives:
+        description: Install required VS workloads
+        module: Microsoft.VisualStudio.DSC
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Community
+        channelId: VisualStudio.17.Release
+        includeRecommended: true
+        Components:
+          - Microsoft.VisualStudio.Workload.NativeGame
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      dependsOn:
+        - vsConfig
+      directives:
+        description: Install Microsoft GDK
+        module: Microsoft.WinGet.DSC
+        allowPrerelease: true
+      settings:
+        id: Microsoft.Gaming.GDK
+        source: winget
+  configurationVersion: 0.2.0

--- a/samples/Repositories/microsoft/terminal/configuration.dsc.yaml
+++ b/samples/Repositories/microsoft/terminal/configuration.dsc.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/microsoft/terminal#prerequisites
+properties:
+  resources:
+    - resource: Microsoft.Windows.Developer/DeveloperMode
+      directives:
+        description: Enable Developer Mode
+        allowPrerelease: true
+      settings:
+        Ensure: Present
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
+        description: Install PowerShell 7
+        allowPrerelease: true
+      settings:
+        id: Microsoft.PowerShell
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
+        description: Install Windows 11 (10.0.22621.0) SDK 
+        allowPrerelease: true
+      settings:
+        id: Microsoft.WindowsSDK
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: vsPackage
+      directives:
+        description: Install Visual Studio 2022 (any edition is OK)
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudio.2022.Community
+        source: winget
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      dependsOn:
+        - vsPackage
+      directives:
+        description: Install required VS workloads
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Community
+        channelId: VisualStudio.17.Release                  
+        vsConfigFile: '${WinGetConfigRoot}\..\.vsconfig'
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
+        description: Install .NET Framework Targeting Pack 4.8
+        allowPrerelease: true
+      settings:
+        id: Microsoft.DotNet.Framework.DeveloperPack_4
+        source: winget
+  configurationVersion: 0.2.0
+  

--- a/samples/Repositories/microsoft/terminal/configuration.dsc.yaml
+++ b/samples/Repositories/microsoft/terminal/configuration.dsc.yaml
@@ -17,7 +17,7 @@ properties:
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
-        description: Install Windows 11 (10.0.22621.0) SDK 
+        description: Install Windows 11 (10.0.22621.0) SDK
         allowPrerelease: true
       settings:
         id: Microsoft.WindowsSDK
@@ -38,7 +38,7 @@ properties:
         allowPrerelease: true
       settings:
         productId: Microsoft.VisualStudio.Product.Community
-        channelId: VisualStudio.17.Release                  
+        channelId: VisualStudio.17.Release
         vsConfigFile: '${WinGetConfigRoot}\..\.vsconfig'
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
@@ -48,4 +48,3 @@ properties:
         id: Microsoft.DotNet.Framework.DeveloperPack_4
         source: winget
   configurationVersion: 0.2.0
-  

--- a/samples/Repositories/microsoft/vscode/configuration.dsc.yaml
+++ b/samples/Repositories/microsoft/vscode/configuration.dsc.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/microsoft/vscode/wiki/How-to-Contribute
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: npm
+      directives:
+        description: Install NodeJS version >=16.17.x and <17
+        allowPrerelease: true
+      settings:
+        id: OpenJS.NodeJS.LTS
+        version: "16.20.0"
+        source: winget
+    - resource: NpmDsc/NpmPackage
+      id: yarn
+      dependsOn:
+        - npm
+      directives:
+        description: Install Yarn
+        allowPrerelease: true
+      settings:
+        Name: 'yarn'
+        Global: true
+        PackageDirectory: '${WinGetConfigRoot}\..\'
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
+        description: Install Python 3.10
+        allowPrerelease: true
+      settings:
+        id: Python.Python.3.10
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: vsPackage
+      directives:
+        description: Install Visual Studio 2022 (any edition is OK)
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudio.2022.BuildTools
+        source: winget
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      dependsOn:
+        - vsPackage
+      directives:
+        description: Install required VS workloads
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.BuildTools
+        channelId: VisualStudio.17.Release
+        includeRecommended: true
+        components:
+          - Microsoft.VisualStudio.Workload.VCTools
+  configurationVersion: 0.2.0

--- a/samples/Repositories/microsoft/winget-cli-restsource/configuration.dsc.yaml
+++ b/samples/Repositories/microsoft/winget-cli-restsource/configuration.dsc.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/microsoft/winget-cli-restsource#building-the-client
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: vsPackage
+      directives:
+        description: Install Visual Studio 2019 (any edition is OK)
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudio.2019.Professional
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
+        description: Install .NET SDK 3.1
+        allowPrerelease: true
+      settings:
+        id: Microsoft.DotNet.SDK.3_1
+        source: winget
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      dependsOn:
+        - vsPackage
+      directives:
+        description: Install required VS workloads
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Professional
+        channelId: VisualStudio.16.Release             
+        components:
+          - Microsoft.VisualStudio.Workload.ManagedDesktop
+          - Microsoft.VisualStudio.Workload.Azure
+          - Microsoft.VisualStudio.Workload.NetWeb
+  configurationVersion: 0.2.0

--- a/samples/Repositories/microsoft/winget-cli-restsource/configuration.dsc.yaml
+++ b/samples/Repositories/microsoft/winget-cli-restsource/configuration.dsc.yaml
@@ -25,7 +25,7 @@ properties:
         allowPrerelease: true
       settings:
         productId: Microsoft.VisualStudio.Product.Professional
-        channelId: VisualStudio.16.Release             
+        channelId: VisualStudio.16.Release
         components:
           - Microsoft.VisualStudio.Workload.ManagedDesktop
           - Microsoft.VisualStudio.Workload.Azure

--- a/samples/Repositories/microsoft/winget-cli/configuration.dsc.yaml
+++ b/samples/Repositories/microsoft/winget-cli/configuration.dsc.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/microsoft/winget-cli#building-the-client
+properties:
+  resources:
+    - resource: Microsoft.Windows.Developer/DeveloperMode
+      directives:
+        description: Enable Developer Mode
+        allowPrerelease: true
+      settings:
+        Ensure: Present
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: vsPackage
+      directives:
+        description: Install Visual Studio 2022 (any edition is OK)
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudio.2022.Community
+        source: winget
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      dependsOn:
+        - vsPackage
+      directives:
+        description: Install required VS workloads from project .vsconfig file
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Community
+        channelId: VisualStudio.17.Release
+        vsConfigFile: '${WinGetConfigRoot}\..\.vsconfig'
+  configurationVersion: 0.2.0

--- a/samples/Repositories/microsoft/winget-create/configuration.dsc.yaml
+++ b/samples/Repositories/microsoft/winget-create/configuration.dsc.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/microsoft/winget-create#building-the-client
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: vsPackage
+      directives:
+        description: Install Visual Studio 2022 Community
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudio.2022.Community
+        source: winget
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      dependsOn:
+        - vsPackage
+      directives:
+        description: Install required VS workloads
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Community
+        channelId: VisualStudio.17.Release                  
+        components:
+          - Microsoft.VisualStudio.Workload.ManagedDesktop
+          - Microsoft.VisualStudio.Workload.Universal
+  configurationVersion: 0.2.0

--- a/samples/Repositories/microsoft/winget-create/configuration.dsc.yaml
+++ b/samples/Repositories/microsoft/winget-create/configuration.dsc.yaml
@@ -18,7 +18,7 @@ properties:
         allowPrerelease: true
       settings:
         productId: Microsoft.VisualStudio.Product.Community
-        channelId: VisualStudio.17.Release                  
+        channelId: VisualStudio.17.Release
         components:
           - Microsoft.VisualStudio.Workload.ManagedDesktop
           - Microsoft.VisualStudio.Workload.Universal

--- a/samples/Repositories/redux/reduxjs/configuration.dsc.yaml
+++ b/samples/Repositories/redux/reduxjs/configuration.dsc.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/reduxjs/redux/blob/master/CONTRIBUTING.md#building-redux
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: npm
+      directives:
+        description: Install Node >=v18.10
+        allowPrerelease: true
+      settings:
+        id: OpenJS.NodeJS
+        source: winget
+    - resource: NpmDsc/NpmPackage
+      id: yarn
+      dependsOn:
+        - npm
+      directives:
+        description: Install Yarn
+        allowPrerelease: true
+      settings:
+        Name: 'yarn'
+        Global: true
+        PackageDirectory: '${WinGetConfigRoot}\..\'
+    - resource: YarnDsc/YarnInstall
+      dependsOn:
+        - yarn
+      directives:
+        description: Install project dependencies
+        allowPrerelease: true
+      settings:
+        PackageDirectory: '${WinGetConfigRoot}\..\'
+  configurationVersion: 0.2.0

--- a/samples/Repositories/tastejs/todomvc/configuration.dsc.yaml
+++ b/samples/Repositories/tastejs/todomvc/configuration.dsc.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/tastejs/todomvc
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: npm
+      directives:
+        description: Install Node version 14+
+        allowPrerelease: true
+      settings:
+        id: OpenJS.NodeJS
+        source: winget
+    - resource: NpmDsc/NpmInstall
+      dependsOn:
+        - npm
+      directives:
+        description: Run 'npm install'
+        allowPrerelease: true
+      settings:
+        PackageDirectory: '${WinGetConfigRoot}\..\'
+  configurationVersion: 0.2.0

--- a/samples/Repositories/videojs/videojs/configuration.dsc.yaml
+++ b/samples/Repositories/videojs/videojs/configuration.dsc.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/videojs/video.js/blob/main/CONTRIBUTING.md#building-videojs-locally
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: npm
+      directives:
+        description: Install Node
+        allowPrerelease: true
+      settings:
+        id: OpenJS.NodeJS
+        source: winget
+    - resource: NpmDsc/NpmInstall
+      dependsOn:
+        - npm
+      directives:
+        description: Run 'npm install'
+        allowPrerelease: true
+      settings:
+        Ensure: 'Present'
+        PackageDirectory: '${WinGetConfigRoot}\..\'
+  configurationVersion: 0.2.0

--- a/samples/Templates/Android Apps/README.md
+++ b/samples/Templates/Android Apps/README.md
@@ -1,0 +1,8 @@
+The WinGet Configuration Files that are contained within the *Android Apps* folder are provided as an initial starting location to building Android applications with a specific software development language. This section will provide you with guidance on what you need, and how to install the software and dependency requirements. Allowing you to focus on learning/experiencing the software development language of your choice.
+
+## Language specific folders
+Each folder in this folder will be labeled with the name of the Software Development language it is associated with. If the language is inclusive of another language, it'll be seperated by a decimal. If the language contains a version specific release that needs to be accounted for, then the version will be considered as the language.
+
+### Example:
+* .\JavaScript.NodeJS
+* .\C++

--- a/samples/Templates/Android Apps/README.md
+++ b/samples/Templates/Android Apps/README.md
@@ -1,8 +1,10 @@
 The WinGet Configuration Files that are contained within the *Android Apps* folder are provided as an initial starting location to building Android applications with a specific software development language. This section will provide you with guidance on what you need, and how to install the software and dependency requirements. Allowing you to focus on learning/experiencing the software development language of your choice.
 
 ## Language specific folders
+
 Each folder in this folder will be labeled with the name of the Software Development language it is associated with. If the language is inclusive of another language, it'll be seperated by a decimal. If the language contains a version specific release that needs to be accounted for, then the version will be considered as the language.
 
-### Example:
+### Example
+
 * .\JavaScript.NodeJS
 * .\C++

--- a/samples/Templates/Introduction/C#/README.md
+++ b/samples/Templates/Introduction/C#/README.md
@@ -1,0 +1,30 @@
+## Understanding WinGet Configuration Files
+This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) (*configuration.dsc.yaml*) that will work with the WinGet command line interface (`winget configure --file [path: configuration.dsc.yaml]`) or can be run using [Microsoft Dev Home](https://learn.microsoft.com/windows/dev-home/) Device Configuration.
+
+When run, the `configuration.dsc.yaml` file will install the following list of applications:
+* Microsoft Visual Studio Community 2022
+    * Required Visual Studio Workloads (ManagedDesktop, Universal)
+* GitHub Desktop
+
+The `configuration.dsc.yaml` file will also enable [Developer Mode](https://learn.microsoft.com/windows/apps/get-started/developer-mode-features-and-debugging) on your device. 
+
+## How to use the WinGet Configuration File
+The following two options are available for running a WinGet Configuration file on your device. 
+
+### 1. Windows Package Manager
+1. Download the `configuration.dsc.yaml` file to your computer.
+1. Open your Windows Start Menu, search and launch "*Windows Terminal*".
+1. Type the following: `CD <C:\Users\User\Download>`
+1. Type the following: `winget configure --file .\configuration.dsc.yaml`
+
+### 2. Dev Home
+1. Download the `configuration.dsc.yaml` file to your computer.
+1. Open your Windows Start Menu, search and launch "*Dev Home*".
+1. Select the *Machine Configuration* button on the left side navigation.
+1. Select the *Configuration file* button
+1. Locate and open the WinGet Configuration file downloaded in "step 1".
+1. Select the "I agree and want to continue" checkbox.
+1. Select the "Set up as admin" button.
+
+## Issues with Configuration file
+If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/devhome/issues/new/choose), or [search existing issues](https://github.com/microsoft/devhome/issues) for a pre-existing issue filed by another user.

--- a/samples/Templates/Introduction/C#/README.md
+++ b/samples/Templates/Introduction/C#/README.md
@@ -1,23 +1,28 @@
-## Understanding WinGet Configuration Files
+# Understanding WinGet Configuration Files
+
 This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) (*configuration.dsc.yaml*) that will work with the WinGet command line interface (`winget configure --file [path: configuration.dsc.yaml]`) or can be run using [Microsoft Dev Home](https://learn.microsoft.com/windows/dev-home/) Device Configuration.
 
 When run, the `configuration.dsc.yaml` file will install the following list of applications:
+
 * Microsoft Visual Studio Community 2022
     * Required Visual Studio Workloads (ManagedDesktop, Universal)
 * GitHub Desktop
 
-The `configuration.dsc.yaml` file will also enable [Developer Mode](https://learn.microsoft.com/windows/apps/get-started/developer-mode-features-and-debugging) on your device. 
+The `configuration.dsc.yaml` file will also enable [Developer Mode](https://learn.microsoft.com/windows/apps/get-started/developer-mode-features-and-debugging) on your device.
 
 ## How to use the WinGet Configuration File
-The following two options are available for running a WinGet Configuration file on your device. 
+
+The following two options are available for running a WinGet Configuration file on your device.
 
 ### 1. Windows Package Manager
+
 1. Download the `configuration.dsc.yaml` file to your computer.
 1. Open your Windows Start Menu, search and launch "*Windows Terminal*".
 1. Type the following: `CD <C:\Users\User\Download>`
 1. Type the following: `winget configure --file .\configuration.dsc.yaml`
 
 ### 2. Dev Home
+
 1. Download the `configuration.dsc.yaml` file to your computer.
 1. Open your Windows Start Menu, search and launch "*Dev Home*".
 1. Select the *Machine Configuration* button on the left side navigation.
@@ -27,4 +32,5 @@ The following two options are available for running a WinGet Configuration file 
 1. Select the "Set up as admin" button.
 
 ## Issues with Configuration file
+
 If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/devhome/issues/new/choose), or [search existing issues](https://github.com/microsoft/devhome/issues) for a pre-existing issue filed by another user.

--- a/samples/Templates/Introduction/C#/configuration.dsc.yaml
+++ b/samples/Templates/Introduction/C#/configuration.dsc.yaml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+
+##########################################################################################################
+# This configuration will install the tools necessary to get started with C# development on Windows      #
+# Reference: https://learn.microsoft.com/visualstudio/get-started/csharp/tutorial-console                #
+#                                                                                                        #
+# This will:                                                                                             #
+#     * Enable Developer Mode                                                                            #
+#     * Install GitHub Desktop                                                                           #
+#     * Install Visual Studio Community 2022                                                             #
+#     * Install Managed Desktop Workload to Visual Studio Community 2022                                 #
+#     * Install Universal Workload to Visual Studio Community 2022                                       #
+#                                                                                                        #
+##########################################################################################################
+properties:
+  resources:
+    - resource: Microsoft.Windows.Developer/DeveloperMode
+      id: Enable
+      directives:
+        description: Enable Developer Mode
+        allowPrerelease: true
+      settings:
+        Ensure: Present
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: GitHub Desktop
+      directives:
+        description: Install GitHub Desktop
+        allowPrerelease: true
+      settings:
+        id: GitHub.GitHubDesktop
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: Visual Studio
+      directives:
+        description: Install Visual Studio 2022 Community
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudio.2022.Community
+        source: winget
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      id: Workloads ManagedDesktop
+      dependsOn:
+        - Visual Studio
+      directives:
+        description: Install required VS Workloads (ManagedDesktop)
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Community
+        channelId: VisualStudio.17.Release                  
+        components:
+          - Microsoft.VisualStudio.Workload.ManagedDesktop
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      id: Workloads Universal
+      dependsOn:
+        - Visual Studio
+      directives:
+        description: Install required VS Workloads (Universal)
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Community
+        channelId: VisualStudio.17.Release                  
+        components:
+          - Microsoft.VisualStudio.Workload.Universal
+  configurationVersion: 0.2.0

--- a/samples/Templates/Introduction/C++/README.md
+++ b/samples/Templates/Introduction/C++/README.md
@@ -1,0 +1,30 @@
+## Understanding WinGet Configuration Files
+This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) (*configuration.dsc.yaml*) that will work with the WinGet command line interface (`winget configure --file [path: configuration.dsc.yaml]`) or can be run using [Microsoft Dev Home](https://learn.microsoft.com/windows/dev-home/) Device Configuration.
+
+When run, the `configuration.dsc.yaml` file will install the following list of applications:
+* Microsoft Visual Studio Community 2022
+* Required Visual Studio Workloads (NativeDesktop, Universal)
+* GitHub Desktop
+
+The `configuration.dsc.yaml` file will also enable [Developer Mode](https://learn.microsoft.com/windows/apps/get-started/developer-mode-features-and-debugging) on your device. 
+
+## How to use the WinGet Configuration File
+The following two options are available for running a WinGet Configuration file on your device. 
+
+### 1. Windows Package Manager
+1. Download the `configuration.dsc.yaml` file to your computer.
+1. Open your Windows Start Menu, search and launch "*Windows Terminal*".
+1. Type the following: `CD <C:\Users\User\Download>`
+1. Type the following: `winget configure --file .\configuration.dsc.yaml`
+
+### 2. Dev Home
+1. Download the `configuration.dsc.yaml` file to your computer.
+1. Open your Windows Start Menu, search and launch "*Dev Home*".
+1. Select the *Machine Configuration* button on the left side navigation.
+1. Select the *Configuration file* button
+1. Locate and open the WinGet Configuration file downloaded in "step 1".
+1. Select the "I agree and want to continue" checkbox.
+1. Select the "Set up as admin" button.
+
+## Issues with Configuration file
+If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/devhome/issues/new/choose), or [search existing issues](https://github.com/microsoft/devhome/issues) for a pre-existing issue filed by another user.

--- a/samples/Templates/Introduction/C++/README.md
+++ b/samples/Templates/Introduction/C++/README.md
@@ -1,23 +1,27 @@
-## Understanding WinGet Configuration Files
+# Understanding WinGet Configuration Files
 This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) (*configuration.dsc.yaml*) that will work with the WinGet command line interface (`winget configure --file [path: configuration.dsc.yaml]`) or can be run using [Microsoft Dev Home](https://learn.microsoft.com/windows/dev-home/) Device Configuration.
 
 When run, the `configuration.dsc.yaml` file will install the following list of applications:
+
 * Microsoft Visual Studio Community 2022
 * Required Visual Studio Workloads (NativeDesktop, Universal)
 * GitHub Desktop
 
-The `configuration.dsc.yaml` file will also enable [Developer Mode](https://learn.microsoft.com/windows/apps/get-started/developer-mode-features-and-debugging) on your device. 
+The `configuration.dsc.yaml` file will also enable [Developer Mode](https://learn.microsoft.com/windows/apps/get-started/developer-mode-features-and-debugging) on your device.
 
 ## How to use the WinGet Configuration File
-The following two options are available for running a WinGet Configuration file on your device. 
+
+The following two options are available for running a WinGet Configuration file on your device.
 
 ### 1. Windows Package Manager
+
 1. Download the `configuration.dsc.yaml` file to your computer.
 1. Open your Windows Start Menu, search and launch "*Windows Terminal*".
 1. Type the following: `CD <C:\Users\User\Download>`
 1. Type the following: `winget configure --file .\configuration.dsc.yaml`
 
 ### 2. Dev Home
+
 1. Download the `configuration.dsc.yaml` file to your computer.
 1. Open your Windows Start Menu, search and launch "*Dev Home*".
 1. Select the *Machine Configuration* button on the left side navigation.
@@ -27,4 +31,5 @@ The following two options are available for running a WinGet Configuration file 
 1. Select the "Set up as admin" button.
 
 ## Issues with Configuration file
+
 If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/devhome/issues/new/choose), or [search existing issues](https://github.com/microsoft/devhome/issues) for a pre-existing issue filed by another user.

--- a/samples/Templates/Introduction/C++/configuration.dsc.yaml
+++ b/samples/Templates/Introduction/C++/configuration.dsc.yaml
@@ -1,0 +1,77 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+
+##########################################################################################################
+# This configuration will install the tools necessary to get started with C++ development on Windows     #
+# Reference: https://learn.microsoft.com/cpp/build/vscpp-step-0-installation?view=msvc-170               #
+#                                                                                                        #
+# This will:                                                                                             #
+#     * Enable Developer Mode                                                                            #
+#     * Install GitHub Desktop                                                                           #
+#     * Install Windows SDK 10.2.22621                                                                   #
+#     * Install Visual Studio Community 2022                                                             #
+#     * Install the Universal workload to Visual Studio Community 2022                                   #
+#     * Instal the NativeDesktop workload to Visual Studio Community 2022                                #
+#                                                                                                        #
+##########################################################################################################
+
+properties:
+  resources:
+    - resource: Microsoft.Windows.Developer/DeveloperMode
+      id: Enable
+      directives:
+        description: Enable Developer Mode
+        allowPrerelease: true
+      settings:
+        Ensure: Present
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: GitHub Desktop
+      directives:
+        description: Install GitHub Desktop
+        allowPrerelease: true
+      settings:
+        id: GitHub.GitHubDesktop
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: VisualStudio
+      directives:
+        description: Install Visual Studio 2022 Community
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudio.2022.Community
+        source: winget
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      id: Workloads NativeDesktop
+      dependsOn:
+        - VisualStudio
+      directives:
+        description: Install required VS Workloads (NativeDesktop)
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Community
+        channelId: VisualStudio.17.Release                  
+        components:
+          - Microsoft.VisualStudio.Workload.NativeDesktop
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      id: Workloads Universal
+      dependsOn:
+        - VisualStudio
+        - Workloads NativeDesktop
+      directives:
+        description: Install required VS Workloads (Universal)
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Community
+        channelId: VisualStudio.17.Release                  
+        components:
+          - Microsoft.VisualStudio.Workload.Universal
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: Windows SDK
+      DependsOn:
+        - VisualStudio
+      directives:
+        description: Install Windows SDK
+        allowPrerelease: true
+      settings:
+        id: Microsoft.WindowsSDK.10.0.22621
+        source: winget
+  configurationVersion: 0.2.0

--- a/samples/Templates/Introduction/JavaScript.NodeJS/README.md
+++ b/samples/Templates/Introduction/JavaScript.NodeJS/README.md
@@ -1,0 +1,27 @@
+## Understanding WinGet Configuration Files
+This folder contains a WinGet Configuration File (*configuration.dsc.yaml*) that will work with the Windows Package Manager command line interface (`winget configure --file [path: configuration.dsc.yaml]`) or can be run using Microsoft Dev Home Device Configuration.
+
+When run, the `configuration.dsc.yaml` file will install the following list of applications:
+* Microsoft Visual Studio Community 2022
+    * Required Visual Studio Workloads (NodeJS, Universal)
+* GitHub Desktop
+
+
+The `configuration.dsc.yaml` file will also enable [Developer Mode](https://learn.microsoft.com/windows/apps/get-started/developer-mode-features-and-debugging) on your device. 
+
+## How to use the WinGet Configuration File
+
+### Windows Package Manager
+1. Download the `configuration.dsc.yaml` file to your computer.
+1. Open your Windows Start Menu, search and launch "*Windows Terminal*".
+1. Type the following: `CD [C:\Users\User\Download]`
+1. Type the following: `winget configure --file .\configuration.dsc.yaml`
+
+### Dev Home
+1. Download the `configuration.dsc.yaml` file to your computer.
+1. Open your Windows Start Menu, search and launch "*Dev Home*".
+1. Select the *Machine Configuration* button on the left side navigation.
+1. Select the *Configuration file* button
+1. Locate and open the WinGet Configuration file downloaded in "step 1".
+1. Select the "I agree and want to continue" checkbox.
+1. Select the "Set up as admin" button.

--- a/samples/Templates/Introduction/JavaScript.NodeJS/README.md
+++ b/samples/Templates/Introduction/JavaScript.NodeJS/README.md
@@ -1,23 +1,26 @@
-## Understanding WinGet Configuration Files
+# Understanding WinGet Configuration Files
+
 This folder contains a WinGet Configuration File (*configuration.dsc.yaml*) that will work with the Windows Package Manager command line interface (`winget configure --file [path: configuration.dsc.yaml]`) or can be run using Microsoft Dev Home Device Configuration.
 
 When run, the `configuration.dsc.yaml` file will install the following list of applications:
+
 * Microsoft Visual Studio Community 2022
     * Required Visual Studio Workloads (NodeJS, Universal)
 * GitHub Desktop
 
-
-The `configuration.dsc.yaml` file will also enable [Developer Mode](https://learn.microsoft.com/windows/apps/get-started/developer-mode-features-and-debugging) on your device. 
+The `configuration.dsc.yaml` file will also enable [Developer Mode](https://learn.microsoft.com/windows/apps/get-started/developer-mode-features-and-debugging) on your device.
 
 ## How to use the WinGet Configuration File
 
 ### Windows Package Manager
+
 1. Download the `configuration.dsc.yaml` file to your computer.
 1. Open your Windows Start Menu, search and launch "*Windows Terminal*".
 1. Type the following: `CD [C:\Users\User\Download]`
 1. Type the following: `winget configure --file .\configuration.dsc.yaml`
 
 ### Dev Home
+
 1. Download the `configuration.dsc.yaml` file to your computer.
 1. Open your Windows Start Menu, search and launch "*Dev Home*".
 1. Select the *Machine Configuration* button on the left side navigation.

--- a/samples/Templates/Introduction/JavaScript.NodeJS/configuration.dsc.yaml
+++ b/samples/Templates/Introduction/JavaScript.NodeJS/configuration.dsc.yaml
@@ -1,0 +1,74 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+
+##########################################################################################################
+# This configuration will install the tools necessary to get started with NodeJS development on Windows  #
+# Reference: https://learn.microsoft.com/windows/dev-environment/javascript/nodejs-on-windows            #
+#                                                                                                        #
+# This will:                                                                                             #
+#     * Enable Developer Mode                                                                            #
+#     * Install GitHub Desktop                                                                           #
+#     * Install NVM                                                                                      #
+#     * Install Visual Studio Community 2022                                                             #
+#     * Install NodeJS Workload to Visual Studio Community 2022                                          #
+#     * Install Universal Workload to Visual Studio Community 2022                                       #
+#                                                                                                        #
+##########################################################################################################
+
+properties:
+  resources:
+    - resource: Microsoft.Windows.Developer/DeveloperMode
+      id: Enable
+      directives:
+        description: Enable Developer Mode
+        allowPrerelease: true
+      settings:
+        Ensure: Present
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: GitHub Desktop
+      directives:
+        description: Install GitHub Desktop
+        allowPrerelease: true
+      settings:
+        id: GitHub.GitHubDesktop
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: NVM
+      directives:
+        description: Install NVM for Windows
+        allowPrerelease: true
+      settings:
+        id: CoreyButler.NVMforWindows
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: Visual Studio
+      directives:
+        description: Install Visual Studio 2022 Community
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudio.2022.Community
+        source: winget
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      id: Workloads NodeJS
+      dependsOn:
+        - Visual Studio
+      directives:
+        description: Install required VS Workloads (NodeJS)
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Community
+        channelId: VisualStudio.17.Release                  
+        components:
+          - Microsoft.Microsoft.VisualStudio.Workload.Node
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      id: Workloads Universal
+      dependsOn:
+        - Visual Studio
+      directives:
+        description: Install required VS Workloads (Universal)
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Community
+        channelId: VisualStudio.17.Release                  
+        components:
+          - Microsoft.VisualStudio.Workload.Universal
+  configurationVersion: 0.2.0

--- a/samples/Templates/Introduction/PowerShell/README.md
+++ b/samples/Templates/Introduction/PowerShell/README.md
@@ -1,0 +1,26 @@
+## Understanding WinGet Configuration Files
+This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) (*configuration.dsc.yaml*) that will work with the WinGet command line interface (`winget configure --file [path: configuration.dsc.yaml]`) or can be run using [Microsoft Dev Home](https://learn.microsoft.com/windows/dev-home/) Device Configuration.
+
+When run, the `configuration.dsc.yaml` file will install the following list of applications:
+* Microsoft Visual Studio Code
+
+## How to use the WinGet Configuration File
+The following two options are available for running a WinGet Configuration file on your device. 
+
+### 1. Windows Package Manager
+1. Download the `configuration.dsc.yaml` file to your computer.
+1. Open your Windows Start Menu, search and launch "*Windows Terminal*".
+1. Type the following: `CD <C:\Users\User\Download>`
+1. Type the following: `winget configure --file .\configuration.dsc.yaml`
+
+### 2. Dev Home
+1. Download the `configuration.dsc.yaml` file to your computer.
+1. Open your Windows Start Menu, search and launch "*Dev Home*".
+1. Select the *Machine Configuration* button on the left side navigation.
+1. Select the *Configuration file* button
+1. Locate and open the WinGet Configuration file downloaded in "step 1".
+1. Select the "I agree and want to continue" checkbox.
+1. Select the "Set up as admin" button.
+
+## Issues with Configuration file
+If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/devhome/issues/new/choose), or [search existing issues](https://github.com/microsoft/devhome/issues) for a pre-existing issue filed by another user.

--- a/samples/Templates/Introduction/PowerShell/README.md
+++ b/samples/Templates/Introduction/PowerShell/README.md
@@ -1,19 +1,24 @@
-## Understanding WinGet Configuration Files
+# Understanding WinGet Configuration Files
+
 This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) (*configuration.dsc.yaml*) that will work with the WinGet command line interface (`winget configure --file [path: configuration.dsc.yaml]`) or can be run using [Microsoft Dev Home](https://learn.microsoft.com/windows/dev-home/) Device Configuration.
 
 When run, the `configuration.dsc.yaml` file will install the following list of applications:
+
 * Microsoft Visual Studio Code
 
 ## How to use the WinGet Configuration File
-The following two options are available for running a WinGet Configuration file on your device. 
+
+The following two options are available for running a WinGet Configuration file on your device.
 
 ### 1. Windows Package Manager
+
 1. Download the `configuration.dsc.yaml` file to your computer.
 1. Open your Windows Start Menu, search and launch "*Windows Terminal*".
 1. Type the following: `CD <C:\Users\User\Download>`
 1. Type the following: `winget configure --file .\configuration.dsc.yaml`
 
 ### 2. Dev Home
+
 1. Download the `configuration.dsc.yaml` file to your computer.
 1. Open your Windows Start Menu, search and launch "*Dev Home*".
 1. Select the *Machine Configuration* button on the left side navigation.
@@ -23,4 +28,5 @@ The following two options are available for running a WinGet Configuration file 
 1. Select the "Set up as admin" button.
 
 ## Issues with Configuration file
+
 If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/devhome/issues/new/choose), or [search existing issues](https://github.com/microsoft/devhome/issues) for a pre-existing issue filed by another user.

--- a/samples/Templates/Introduction/PowerShell/configuration.dsc.yaml
+++ b/samples/Templates/Introduction/PowerShell/configuration.dsc.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/microsoft/PowerToys/blob/main/doc/devdocs/readme.md#compiling-powertoys
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: Visual Studio Code
+      directives:
+        description: Install Visual Studio Code
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudioCode
+        source: winget
+  configurationVersion: 0.2.0

--- a/samples/Templates/Introduction/Python3.12/README.md
+++ b/samples/Templates/Introduction/Python3.12/README.md
@@ -1,0 +1,31 @@
+## Understanding WinGet Configuration Files
+This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) (*configuration.dsc.yaml*) that will work with the WinGet command line interface (`winget configure --file [path: configuration.dsc.yaml]`) or can be run using [Microsoft Dev Home](https://learn.microsoft.com/windows/dev-home/) Device Configuration.
+
+When run, the `configuration.dsc.yaml` file will install the following list of applications:
+* Microsoft Visual Studio Community 2022
+    * Required Visual Studio Workloads (Python)
+* GitHub Desktop
+* Python 3.12
+
+The `configuration.dsc.yaml` file will also enable [Developer Mode](https://learn.microsoft.com/windows/apps/get-started/developer-mode-features-and-debugging) on your device. 
+
+## How to use the WinGet Configuration File
+The following two options are available for running a WinGet Configuration file on your device. 
+
+### 1. Windows Package Manager
+1. Download the `configuration.dsc.yaml` file to your computer.
+1. Open your Windows Start Menu, search and launch "*Windows Terminal*".
+1. Type the following: `CD <C:\Users\User\Download>`
+1. Type the following: `winget configure --file .\configuration.dsc.yaml`
+
+### 2. Dev Home
+1. Download the `configuration.dsc.yaml` file to your computer.
+1. Open your Windows Start Menu, search and launch "*Dev Home*".
+1. Select the *Machine Configuration* button on the left side navigation.
+1. Select the *Configuration file* button
+1. Locate and open the WinGet Configuration file downloaded in "step 1".
+1. Select the "I agree and want to continue" checkbox.
+1. Select the "Set up as admin" button.
+
+## Issues with Configuration file
+If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/devhome/issues/new/choose), or [search existing issues](https://github.com/microsoft/devhome/issues) for a pre-existing issue filed by another user.

--- a/samples/Templates/Introduction/Python3.12/README.md
+++ b/samples/Templates/Introduction/Python3.12/README.md
@@ -1,24 +1,29 @@
-## Understanding WinGet Configuration Files
+# Understanding WinGet Configuration Files
+
 This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) (*configuration.dsc.yaml*) that will work with the WinGet command line interface (`winget configure --file [path: configuration.dsc.yaml]`) or can be run using [Microsoft Dev Home](https://learn.microsoft.com/windows/dev-home/) Device Configuration.
 
 When run, the `configuration.dsc.yaml` file will install the following list of applications:
+
 * Microsoft Visual Studio Community 2022
     * Required Visual Studio Workloads (Python)
 * GitHub Desktop
 * Python 3.12
 
-The `configuration.dsc.yaml` file will also enable [Developer Mode](https://learn.microsoft.com/windows/apps/get-started/developer-mode-features-and-debugging) on your device. 
+The `configuration.dsc.yaml` file will also enable [Developer Mode](https://learn.microsoft.com/windows/apps/get-started/developer-mode-features-and-debugging) on your device.
 
 ## How to use the WinGet Configuration File
-The following two options are available for running a WinGet Configuration file on your device. 
+
+The following two options are available for running a WinGet Configuration file on your device.
 
 ### 1. Windows Package Manager
+
 1. Download the `configuration.dsc.yaml` file to your computer.
 1. Open your Windows Start Menu, search and launch "*Windows Terminal*".
 1. Type the following: `CD <C:\Users\User\Download>`
 1. Type the following: `winget configure --file .\configuration.dsc.yaml`
 
 ### 2. Dev Home
+
 1. Download the `configuration.dsc.yaml` file to your computer.
 1. Open your Windows Start Menu, search and launch "*Dev Home*".
 1. Select the *Machine Configuration* button on the left side navigation.
@@ -28,4 +33,5 @@ The following two options are available for running a WinGet Configuration file 
 1. Select the "Set up as admin" button.
 
 ## Issues with Configuration file
+
 If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/devhome/issues/new/choose), or [search existing issues](https://github.com/microsoft/devhome/issues) for a pre-existing issue filed by another user.

--- a/samples/Templates/Introduction/Python3.12/configuration.dsc.yaml
+++ b/samples/Templates/Introduction/Python3.12/configuration.dsc.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+
+##########################################################################################################
+# This configuration will install the tools necessary to get started with Python development on Windows  #
+# Reference: https://learn.microsoft.com/windows/python/beginners                                        #
+#                                                                                                        #
+# This will:                                                                                             #
+#     * Enable Developer Mode                                                                            #
+#     * Install GitHub Desktop                                                                           #
+#     * Install Python                                                                                   #
+#     * Install Visual Studio Code                                                                       #
+#                                                                                                        #
+##########################################################################################################
+
+properties:
+  resources:
+    - resource: Microsoft.Windows.Developer/DeveloperMode
+      id: Enable
+      directives:
+        description: Enable Developer Mode
+        allowPrerelease: true
+      settings:
+        Ensure: Present
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: Python 3.12
+      directives:
+        description: Install Python 3.12
+        allowPrerelease: true
+      settings:
+        id: Python.Python.3.12
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: GitHub Desktop
+      directives:
+        description: Install GitHub Desktop
+        allowPrerelease: true
+      settings:
+        id: GitHub.GitHubDesktop
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: VisualStudio Code
+      directives:
+        description: Install Visual Studio Code
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudioCode
+        source: winget
+  configurationVersion: 0.2.0

--- a/samples/Templates/Introduction/README.md
+++ b/samples/Templates/Introduction/README.md
@@ -1,0 +1,8 @@
+This directory contains different [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration files](https://learn.microsoft.com/windows/package-manager/configuration/) that will be used for setting up your device for a specific software development language. These files are designed specifically for providing an introduction to software development, creating the default *Hello World* project, without having to focus on understanding the complexities of what needs to be installed, and how should it be configured.
+
+## Language specific folders (Naming Standard)
+Each folder in this folder will be labeled with the name of the Software Development language it is associated with. If the language is inclusive of another language, it'll be seperated by a decimal. If the language contains a version specific release that needs to be accounted for, then the version will be considered as the language.
+
+### Example:
+* .\JavaScript.NodeJS
+* .\Python3.11

--- a/samples/Templates/Introduction/README.md
+++ b/samples/Templates/Introduction/README.md
@@ -1,8 +1,10 @@
 This directory contains different [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration files](https://learn.microsoft.com/windows/package-manager/configuration/) that will be used for setting up your device for a specific software development language. These files are designed specifically for providing an introduction to software development, creating the default *Hello World* project, without having to focus on understanding the complexities of what needs to be installed, and how should it be configured.
 
 ## Language specific folders (Naming Standard)
+
 Each folder in this folder will be labeled with the name of the Software Development language it is associated with. If the language is inclusive of another language, it'll be seperated by a decimal. If the language contains a version specific release that needs to be accounted for, then the version will be considered as the language.
 
-### Example:
+### Example
+
 * .\JavaScript.NodeJS
 * .\Python3.11

--- a/samples/Templates/README.md
+++ b/samples/Templates/README.md
@@ -1,0 +1,13 @@
+This section is reflective of the type of software development workloads that will be performed. If you are new to software development or are looking for an introduction to the software development language, we recommend visiting the [Introduction](./Introduction/) section, which has more information about various languages.
+
+## Android Apps
+This directory focuses on software development languages used for developing Android Apps, with a device setup that is focused on creating and testing Android apps.
+
+## Introduction
+This directory focuses on Getting Started with a particular language. The device setup flows will focus on the base requirements needed for creating a *Hello World* or similar project. This directory is recommended for individuals interested in learning how to develop software.
+
+## Web Development
+This directory focuses on software development languages used for developing websites and web apps. The device setup flows will focus on web app development.
+
+## Xbox Games
+This directory focuses on software development languages used for developing Xbox games. The device setup flows will focus on any development / testing requirements.

--- a/samples/Templates/Web Development/README.md
+++ b/samples/Templates/Web Development/README.md
@@ -1,0 +1,8 @@
+The WinGet Configuration Files that are contained within the *Web Development* folder are provided as an initial starting location to building Web applications with a specific software development language. This section will provide you with guidance on what you need, and how to install the software and dependency requirements. Allowing you to focus on learning/experiencing the software development language of your choice.
+
+## Language specific folders
+Each folder in this folder will be labeled with the name of the Software Development language it is associated with. If the language is inclusive of another language, it'll be seperated by a decimal. If the language contains a version specific release that needs to be accounted for, then the version will be considered as the language.
+
+### Example:
+* .\JavaScript.NodeJS
+* .\C++

--- a/samples/Templates/Web Development/README.md
+++ b/samples/Templates/Web Development/README.md
@@ -1,8 +1,10 @@
 The WinGet Configuration Files that are contained within the *Web Development* folder are provided as an initial starting location to building Web applications with a specific software development language. This section will provide you with guidance on what you need, and how to install the software and dependency requirements. Allowing you to focus on learning/experiencing the software development language of your choice.
 
 ## Language specific folders
+
 Each folder in this folder will be labeled with the name of the Software Development language it is associated with. If the language is inclusive of another language, it'll be seperated by a decimal. If the language contains a version specific release that needs to be accounted for, then the version will be considered as the language.
 
-### Example:
+### Example
+
 * .\JavaScript.NodeJS
 * .\C++

--- a/samples/Templates/Xbox Games/README.md
+++ b/samples/Templates/Xbox Games/README.md
@@ -1,0 +1,8 @@
+The WinGet Configuration Files that are contained within the *Xbox Games* folder are provided as an initial starting location to building Xbox games with a specific software development language. This section will provide you with guidance on what you need, and how to install the software and dependency requirements. Allowing you to focus on learning/experiencing the software development language of your choice.
+
+## Language specific folders
+Each folder in this folder will be labeled with the name of the Software Development language it is associated with. If the language is inclusive of another language, it'll be seperated by a decimal. If the language contains a version specific release that needs to be accounted for, then the version will be considered as the language.
+
+### Example:
+* .\JavaScript.NodeJS
+* .\C++

--- a/samples/Templates/Xbox Games/README.md
+++ b/samples/Templates/Xbox Games/README.md
@@ -1,8 +1,10 @@
 The WinGet Configuration Files that are contained within the *Xbox Games* folder are provided as an initial starting location to building Xbox games with a specific software development language. This section will provide you with guidance on what you need, and how to install the software and dependency requirements. Allowing you to focus on learning/experiencing the software development language of your choice.
 
 ## Language specific folders
+
 Each folder in this folder will be labeled with the name of the Software Development language it is associated with. If the language is inclusive of another language, it'll be seperated by a decimal. If the language contains a version specific release that needs to be accounted for, then the version will be considered as the language.
 
-### Example:
+### Example
+
 * .\JavaScript.NodeJS
 * .\C++


### PR DESCRIPTION
This PR copies over the entire `sampleConfigurations` folder from https://github.com/microsoft/devhome/tree/main/docs/sampleConfigurations into a `sample` folder in this repository. The first commit is a ditto copy of the folder from devhome repo. I only applied some general lint fixes and updated URLs which you can see in the next commits