### PR TITLE
Update NodeJS sample

### DIFF
--- a/samples/Templates/Introduction/JavaScript.NodeJS/configuration.dsc.yaml
+++ b/samples/Templates/Introduction/JavaScript.NodeJS/configuration.dsc.yaml
@@ -27,7 +27,6 @@ properties:
       id: GitHub Desktop
       directives:
         description: Install GitHub Desktop
-        allowPrerelease: true
       settings:
         id: GitHub.GitHubDesktop
         source: winget
@@ -35,7 +34,6 @@ properties:
       id: NVM
       directives:
         description: Install NVM for Windows
-        allowPrerelease: true
       settings:
         id: CoreyButler.NVMforWindows
         source: winget
@@ -43,7 +41,6 @@ properties:
       id: Visual Studio
       directives:
         description: Install Visual Studio 2022 Community
-        allowPrerelease: true
       settings:
         id: Microsoft.VisualStudio.2022.Community
         source: winget
@@ -56,7 +53,7 @@ properties:
         allowPrerelease: true
       settings:
         productId: Microsoft.VisualStudio.Product.Community
-        channelId: VisualStudio.17.Release                  
+        channelId: VisualStudio.17.Release
         components:
           - Microsoft.Microsoft.VisualStudio.Workload.Node
     - resource: Microsoft.VisualStudio.DSC/VSComponents
@@ -68,7 +65,7 @@ properties:
         allowPrerelease: true
       settings:
         productId: Microsoft.VisualStudio.Product.Community
-        channelId: VisualStudio.17.Release                  
+        channelId: VisualStudio.17.Release
         components:
           - Microsoft.VisualStudio.Workload.Universal
   configurationVersion: 0.2.0


### PR DESCRIPTION
Microsoft.WinGet.DSC is stable so "allowPrerelease: true" is no longer necessary.

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-dsc).
- [ ] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-dsc/pull/141)