### PR TITLE
Add app advanced settings and execution aliases

### DIFF
--- a/.github/actions/spelling/expect/generic_terms.txt
+++ b/.github/actions/spelling/expect/generic_terms.txt
@@ -20,3 +20,8 @@ usr
 versioning
 VGpu
 ADDLOCAL
+Aic 
+Cdp 
+reparsepoint 
+Stubification
+XExe

--- a/resources/Help/Microsoft.Windows.Setting.Apps/AdvancedAppSettings.md
+++ b/resources/Help/Microsoft.Windows.Setting.Apps/AdvancedAppSettings.md
@@ -1,0 +1,40 @@
+---
+external help file: Microsoft.Windows.Setting.Apps.psm1-Help.xml
+Module Name: Microsoft.Windows.Setting.Apps
+ms.date:  01/10/2025
+online version:
+schema: 2.0.0
+title: AdvancedAppSettings
+---
+
+# AppExecutionAliases
+
+## SYNOPSIS
+
+The `AdvancedAppSettings` DSC Resource allows you to manage advanced application settings on Windows, including app source preferences, device experience sharing, and app archiving.
+
+## DESCRIPTION
+
+The `AdvancedAppSettings` DSC Resource allows you to manage advanced application settings on Windows, including app source preferences, device experience sharing, and app archiving.
+
+## PARAMETERS
+
+| **Parameter**           | **Attribute** | **DataType** | **Description**                                                                 | **Allowed Values**                                    |
+|-------------------------|---------------|--------------|---------------------------------------------------------------------------------|-------------------------------------------------------|
+| `SID`                   | Key           | String       | The security identifier. This is a key property and should not be set manually. | N/A                                                   |
+| `AppSourcePreference`   | Optional      | String       | Specifies the source preference for installing applications.                    | { Anywhere, Recommendations, PreferStore, StoreOnly } |
+| `ShareDeviceExperience` | Optional      | String       | Specifies the device experience sharing setting.                                | { Off, Device, Everyone }                             |
+| `ArchiveApp`            | Optional      | Boolean      | Indicates whether to enable app archiving.                                      | `True` or `False`                                     |
+
+## EXAMPLES
+
+### EXAMPLE 1 - Example that adds `myAppAlias.exe` as app execution alias
+
+```powershell
+Invoke-DscResource -ModuleName Microsoft.Windows.Setting.Apps -Name AppExecutionAliases -Method Set -Property @{
+    ExecutionAliasName = 'myAppAlias.exe';
+    Exist = $true;
+}
+
+# This example ensures that the execution alias 'myAppAlias.exe' exists.
+```

--- a/resources/Help/Microsoft.Windows.Setting.Apps/AppExecutionAliases.md
+++ b/resources/Help/Microsoft.Windows.Setting.Apps/AppExecutionAliases.md
@@ -1,0 +1,38 @@
+---
+external help file: Microsoft.Windows.Setting.Apps.psm1-Help.xml
+Module Name: Microsoft.Windows.Setting.Apps
+ms.date:  01/10/2025
+online version:
+schema: 2.0.0
+title: AppExecutionAliases
+---
+
+# AppExecutionAliases
+
+## SYNOPSIS
+
+The `AppExecutionAliases` DSC Resource allows you to manage execution aliases for applications on Windows.
+
+## DESCRIPTION
+
+The `AppExecutionAliases` DSC Resource allows you to manage execution aliases for applications on Windows.
+
+## PARAMETERS
+
+|    **Parameter**     | **Attribute**  | **DataType** |                                            **Description**                                            |  **Allowed Values**   |
+| -------------------- | -------------- | ------------ | ----------------------------------------------------------------------------------------------------- | --------------------- |
+| `ExecutionAliasName` | Key, Mandatory | String       | The path to the image file that will be used as the desktop background picture.                       | Any valid image path. |
+| `Exist`              | Optional       | Boolean      | Indicates whether the execution alias should exist. This is an optional parameter. Defaults to `True` | `True` or `False`     |
+
+## EXAMPLES
+
+### EXAMPLE 1 - Example that adds `myAppAlias.exe` as app execution alias
+
+```powershell
+Invoke-DscResource -ModuleName Microsoft.Windows.Setting.Apps -Name AppExecutionAliases -Method Set -Property @{
+    ExecutionAliasName = 'myAppAlias.exe';
+    Exist = $true;
+}
+
+# This example ensures that the execution alias 'myAppAlias.exe' exists.
+```

--- a/resources/Microsoft.Windows.Setting.Apps/Microsoft.Windows.Setting.Apps.psd1
+++ b/resources/Microsoft.Windows.Setting.Apps/Microsoft.Windows.Setting.Apps.psd1
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+@{
+    RootModule           = 'Microsoft.Windows.Setting.Apps.psm1'
+    ModuleVersion        = '0.1.0'
+    GUID                 = 'ac5fb135-25ec-4029-b8d4-534216a9b6ea'
+    Author               = 'Microsoft Corporation'
+    CompanyName          = 'Microsoft Corporation'
+    Copyright            = '(c) Microsoft Corp. All rights reserved.'
+    Description          = 'The DSC module for Windows Apps'
+    PowerShellVersion    = '7.4'
+    DscResourcesToExport = @(
+    )
+    PrivateData          = @{
+        PSData = @{
+            # Tags applied to this module. These help with module discovery in online galleries.
+            Tags       = @(
+            
+            )
+
+            # A URL to the license for this module.
+            LicenseUri = 'https://github.com/microsoft/winget-dsc/blob/main/LICENSE'
+
+            # A URL to the main website for this project.
+            ProjectUri = 'https://github.com/microsoft/winget-dsc'
+
+            # Prerelease string of this module
+            Prerelease = 'alpha'
+        }
+    }
+}

--- a/resources/Microsoft.Windows.Setting.Apps/Microsoft.Windows.Setting.Apps.psd1
+++ b/resources/Microsoft.Windows.Setting.Apps/Microsoft.Windows.Setting.Apps.psd1
@@ -10,12 +10,15 @@
     Description          = 'The DSC module for Windows Apps'
     PowerShellVersion    = '7.4'
     DscResourcesToExport = @(
+        'AdvancedAppSettings',
+        'AppExecutionAliases'
     )
     PrivateData          = @{
         PSData = @{
             # Tags applied to this module. These help with module discovery in online galleries.
             Tags       = @(
-            
+                'PSDscResource_AdvancedAppSettings',
+                'PSDscResource_AppExecutionAliases'
             )
 
             # A URL to the license for this module.

--- a/resources/Microsoft.Windows.Setting.Apps/Microsoft.Windows.Setting.Apps.psm1
+++ b/resources/Microsoft.Windows.Setting.Apps/Microsoft.Windows.Setting.Apps.psm1
@@ -1,0 +1,330 @@
+if ([string]::IsNullOrEmpty($env:TestRegistryPath)) {
+    $global:ExplorerPath = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Explorer'
+    $global:CdpPath = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\CDP\'
+    $global:ArchiveAppPath = ('HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\InstallService\Stubification\{0}\' -f ([System.Security.Principal.WindowsIdentity]::GetCurrent()).User.Value)
+    $global:AppPath = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\'
+    
+} else {
+    $global:ExplorerPath = $env:TestRegistryPath
+}
+
+#region Enums
+enum AppSourcePreference {
+    Anywhere
+    Recommendations
+    PreferStore
+    StoreOnly
+}
+
+enum ShareDeviceExperience {
+    Off
+    Device
+    Everyone
+}
+#endregion Enums
+
+#region Functions
+function DoesRegistryKeyPropertyExist {
+    param (
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    # Get-ItemProperty will return $null if the registry key property does not exist.
+    $itemProperty = Get-ItemProperty -Path $Path -Name $Name -ErrorAction SilentlyContinue
+    return $null -ne $itemProperty
+}
+
+function Set-AdvancedAppSettings {
+    param (
+        [AppSourcePreference] $AppSourcePreference,
+        [ShareDeviceExperience] $ShareDeviceExperience,
+        [nullable[bool]] $ArchiveApp
+    )
+
+    if ($null -ne $AppSourcePreference) {
+        if (-not (DoesRegistryKeyPropertyExist -Path $global:ExplorerPath -Name ([AdvancedAppSettings]::AppSourcePreferenceProperty))) {
+            New-ItemProperty -Path $global:ExplorerPath -Name ([AdvancedAppSettings]::AppSourcePreferenceProperty) -Value $appSourcePreference -PropertyType String | Out-Null
+        }
+        Set-ItemProperty -Path $global:ExplorerPath -Name ([AdvancedAppSettings]::AppSourcePreferenceProperty) -Value $appSourcePreference
+    }
+
+    if ($null -ne $ShareDeviceExperience) {
+        $shareDeviceExperienceValue = switch ($ShareDeviceExperience) {
+            'Off' { 0 }
+            'Device' { 1 }
+            'Everyone' { 2 }
+            default { 0 }
+        }
+
+        if (-not (DoesRegistryKeyPropertyExist -Path $global:CdpPath -Name ([AdvancedAppSettings]::ShareDeviceExperienceProperty1))) {
+            New-ItemProperty -Path $global:CdpPath -Name ([AdvancedAppSettings]::ShareDeviceExperienceProperty1) -Value $shareDeviceExperienceValue -PropertyType DWord | Out-Null
+        }
+
+        if (-not (DoesRegistryKeyPropertyExist -Path $global:CdpPath -Name ([AdvancedAppSettings]::ShareDeviceExperienceProperty2))) {
+            New-ItemProperty -Path $global:CdpPath -Name ([AdvancedAppSettings]::ShareDeviceExperienceProperty2) -Value $shareDeviceExperienceValue -PropertyType DWord | Out-Null
+        }
+        Set-ItemProperty -Path $global:CdpPath -Name ([AdvancedAppSettings]::ShareDeviceExperienceProperty1) -Value $shareDeviceExperienceValue
+        Set-ItemProperty -Path $global:CdpPath -Name ([AdvancedAppSettings]::ShareDeviceExperienceProperty2) -Value $shareDeviceExperienceValue
+    }
+
+    if ($null -ne $ArchiveApp) {
+        if (-not (Test-Path -Path $global:ArchiveAppPath -ErrorAction SilentlyContinue)) {
+            New-Item -Path $global:ArchiveAppPath -Force
+        }
+
+        if (-not (DoesRegistryKeyPropertyExist -Path $global:ArchiveAppPath -Name ([AdvancedAppSettings]::ArchiveAppProperty))) {
+            New-ItemProperty -Path $global:ArchiveAppPath -Name ([AdvancedAppSettings]::ArchiveAppProperty) -Value ([int]$ArchiveApp) -PropertyType DWord | Out-Null
+        }
+        Set-ItemProperty -Path $global:ArchiveAppPath -Name ([AdvancedAppSettings]::ArchiveAppProperty) -Value ([int]$ArchiveApp)
+    }
+}
+
+function Resolve-AppXExePath {
+    param(
+        [Parameter(ValueFromPipeline)]
+        [Alias('PSPath')]
+        [string] $LiteralPath
+    )
+      
+    process {
+        $fullName = Convert-Path -LiteralPath $LiteralPath
+        if (-not $?) { return }
+      
+        $hexDump = fsutil reparsepoint query $fullName 2>&1
+        if ($LASTEXITCODE) { Throw $hexDump }
+      
+        [byte[]] $bytes = -split ( -join ($hexDump -match '^[a-f0-9]+:' -replace '^[a-f0-9]+:\s+(((?:[a-f0-9]{2}) +){1,16}).+$', '$1')) -replace '^', '0x'
+        
+        $props = [System.Text.Encoding]::Unicode.GetString($bytes) -split "`0"
+
+        [PSCustomObject] @{
+            AppId  = $props[2]
+            Target = $props[3]
+        } 
+    }
+}
+
+function Set-AppExecutionAlias {
+    param (
+        [Parameter(Mandatory)]
+        [string]$ExecutionAliasName,
+
+        [Parameter(Mandatory)]
+        [bool]$Exist
+    )
+
+    $windowsAppsPath = "$env:LOCALAPPDATA\Microsoft\WindowsApps"
+    $aliasPath = Get-ChildItem -Path $windowsAppsPath -Recurse | Where-Object { $_.Name -eq $ExecutionAliasName } | Select-Object -First 1
+
+    if ($Exist) {
+        if ($aliasPath) {
+            $resolvedPath = Resolve-AppXExePath -LiteralPath $aliasPath.FullName
+            $appPath = "$global:AppPath\$ExecutionAliasName"
+            
+            if (-not (Test-Path -Path $appPath)) {
+                New-Item -Path $appPath -Force | Out-Null
+            }
+
+            if (-not (DoesRegistryKeyPropertyExist -Path $appPath -Name '(Default)')) {
+                New-ItemProperty -Path $appPath -Name '(Default)' -Value $resolvedPath.Target -PropertyType String | Out-Null
+            } 
+            Set-ItemProperty -Path $appPath -Name '(Default)' -Value $resolvedPath.Target
+            
+            $Parent = Split-Path -Path $resolvedPath.Target -Parent
+            if (-not (DoesRegistryKeyPropertyExist -Path $appPath -Name 'Path')) {
+                New-ItemProperty -Path $appPath -Name 'Path' -Value $Parent -PropertyType String | Out-Null
+            }
+            Set-ItemProperty -Path $appPath -Name 'Path' -Value "$Parent\"
+        } else {
+            Throw "Executable $ExecutionAliasName not found in $windowsAppsPath. Please install the application installer."
+        }
+    } else {
+        $appPath = "$global:AppPath\$ExecutionAliasName"
+        # Additional check to ensure that the path exists before attempting to remove it.
+        if (Test-Path -Path $appPath) {
+            Remove-Item -Path $appPath -Force
+        }
+    }
+}
+
+#endregion Functions
+
+#region Classes
+<#
+.SYNOPSIS
+    The `AdvancedAppSettings` DSC Resource allows you to manage advanced application settings on Windows, including app source preferences, device experience sharing, and app archiving.
+
+.PARAMETER SID
+    The security identifier. This is a key property and should not be set manually.
+
+.PARAMETER AppSourcePreference
+    Specifies the source preference for installing applications. Possible values are: Anywhere, Recommendations, PreferStore, StoreOnly.
+
+.PARAMETER ShareDeviceExperience
+    Specifies the device experience sharing setting. Possible values are: Off, Device, Everyone.
+
+.PARAMETER ArchiveApp
+    Indicates whether to enable app archiving. This is an optional parameter.
+
+.EXAMPLE
+    PS C:\> Invoke-DscResource -ModuleName Microsoft.Windows.Setting.Apps -Name AdvancedAppSettings -Method Set -Property @{
+        AppSourcePreference = 'PreferStore';
+        ShareDeviceExperience = 'Everyone';
+        ArchiveApp = $true;
+    }
+
+    This example sets the advanced app settings for the specified user to prefer store apps, share device experience with everyone, and enable app archiving.
+#>
+[DscResource()]
+class AdvancedAppSettings {
+    # Key required. Do not set.
+    [DscProperty(Key)] 
+    [string] $SID
+
+    [DscProperty()]
+    [AppSourcePreference] $AppSourcePreference
+
+    [DscProperty()]
+    [ShareDeviceExperience] $ShareDeviceExperience
+
+    [DscProperty()]
+    [nullable[bool]] $ArchiveApp
+
+    static hidden [string] $AppSourcePreferenceProperty = 'AicEnabled'
+    static hidden [string] $ShareDeviceExperienceProperty1 = 'RomeSdkChannelUserAuthzPolicy'
+    static hidden [string] $ShareDeviceExperienceProperty2 = 'CdpSessionUserAuthzPolicy'
+    static hidden [string] $ArchiveAppProperty = 'EnableAppOffloading'
+
+    [AdvancedAppSettings] Get() {
+        $currentState = [AdvancedAppSettings]::new()
+        $currentState.AppSourcePreference = [AdvancedAppSettings]::GetAppSourcePreference()
+        $currentState.ShareDeviceExperience = [AdvancedAppSettings]::GetShareDeviceExperience()
+        $currentState.ArchiveApp = [AdvancedAppSettings]::GetArchiveApp()
+
+        return $currentState
+    }
+
+    [bool] Test() {
+        $currentState = $this.Get()
+
+        if (($null -ne $this.AppSourcePreference) -and ($this.AppSourcePreference -ne $currentState.AppSourcePreference)) {
+            return $false
+        }
+
+        if (($null -ne $this.ShareDeviceExperience) -and ($this.ShareDeviceExperience -ne $currentState.ShareDeviceExperience)) {
+            return $false
+        }
+
+        if (($null -ne $this.ArchiveApp) -and ($this.ArchiveApp -ne $currentState.ArchiveApp)) {
+            return $false
+        }
+
+        return $true
+    }
+
+    [void] Set() {
+        if (-not ($this.Test())) {
+            Set-AdvancedAppSettings -AppSourcePreference $this.AppSourcePreference -ShareDeviceExperience $this.ShareDeviceExperience -ArchiveApp $this.ArchiveApp
+        }
+    }
+
+    #region AdvancedAppSettings helper functions
+    static [AppSourcePreference] GetAppSourcePreference() {
+        $preference = try {
+            # Catching it this way. See issue: https://github.com/PowerShell/PowerShell/issues/5906
+            Get-ItemPropertyValue -Path $global:ExplorerPath -Name ([AdvancedAppSettings]::AppSourcePreferenceProperty) -ErrorAction Stop
+        } catch {
+            'Anywhere'
+        }
+        
+        return [AppSourcePreference]::$preference
+    }
+
+    static [ShareDeviceExperience] GetShareDeviceExperience() {
+        # Assuming that if the first property does not exist, the second one will not exist either.
+        if (-not (DoesRegistryKeyPropertyExist -Path $global:CdpPath -Name ([AdvancedAppSettings]::ShareDeviceExperienceProperty1))) {
+            return [ShareDeviceExperience]::Off
+        } else {
+            $deviceExperience = Get-ItemPropertyValue -Path $global:CdpPath -Name ([AdvancedAppSettings]::ShareDeviceExperienceProperty1)
+            $experience = switch ($deviceExperience) {
+                0 { [ShareDeviceExperience]::Off }
+                1 { [ShareDeviceExperience]::Device }
+                2 { [ShareDeviceExperience]::Everyone }
+                default { [ShareDeviceExperience]::Off }
+            }
+
+            return $experience
+        }
+    }
+
+    static [bool] GetArchiveApp() {
+        if (-not (DoesRegistryKeyPropertyExist -Path $global:ArchiveAppPath -Name ([AdvancedAppSettings]::ArchiveAppProperty))) {
+            return $true
+        } else {
+            $archiveValue = Get-ItemPropertyValue -Path $global:ArchiveAppPath -Name ([AdvancedAppSettings]::ArchiveAppProperty)
+            return ($archiveValue -eq 1)
+        }
+    }
+}
+
+<#
+.SYNOPSIS
+    The `AppExecutionAliases` DSC Resource allows you to manage execution aliases for applications on Windows.
+
+.PARAMETER ExecutionAliasName
+    The name of the execution alias. This is a key property.
+
+.PARAMETER Exist
+    Indicates whether the execution alias should exist. This is an optional parameter.
+
+.EXAMPLE
+    PS C:\> Invoke-DscResource -ModuleName Microsoft.Windows.Setting.Apps -Name AppExecutionAliases -Method Set -Property @{
+        ExecutionAliasName = 'myAppAlias.exe';
+        Exist = $true;
+    }
+
+    This example ensures that the execution alias 'myAppAlias.exe' exists.
+#>
+[DscResource()]
+class AppExecutionAliases {
+    [DscProperty(Key, Mandatory)]
+    [string] $ExecutionAliasName
+
+    [DscProperty()]
+    [bool] $Exist = $true
+
+    AppExecutionAliases () {
+    }
+
+    AppExecutionAliases ([string] $ExecutionAliasName) {
+        $this.ExecutionAliasName = $ExecutionAliasName
+        $this.Exist = (Test-Path -Path "$global:AppPath\$ExecutionAliasName")
+    }
+
+    [AppExecutionAliases[]] Get() {
+        $currentState = [AppExecutionAliases]::new($this.ExecutionAliasName)
+
+        return $currentState
+    }
+
+    [bool] Test() {
+        $currentState = $this.Get()
+
+        if ($this.Exist -ne $currentState.Exist) {
+            return $false
+        }
+
+        return $true
+    }
+
+    [void] Set() {
+        if (-not ($this.Test())) {
+            Set-AppExecutionAlias -ExecutionAliasName $this.ExecutionAliasName -Exist $this.Exist
+        }
+    }
+}
+#endregion Classes

--- a/tests/Microsoft.Windows.Setting.Apps/Microsoft.Windows.Setting.Apps.Tests.ps1
+++ b/tests/Microsoft.Windows.Setting.Apps/Microsoft.Windows.Setting.Apps.Tests.ps1
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+using module Microsoft.Windows.Setting.Apps
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+<#
+.Synopsis
+   Pester tests related to the Microsoft.Windows.Setting.Apps PowerShell module.
+#>
+
+BeforeAll {
+    if ((Get-Module -ListAvailable -Name PSDesiredStateConfiguration -ErrorAction SilentlyContinue).Version -eq '2.0.7') {
+        Install-Module -Name PSDesiredStateConfiguration -Force -SkipPublisherCheck
+    }
+
+    Import-Module Microsoft.Windows.Setting.Apps -Force
+}
+
+Describe 'List available DSC resources' {
+    It 'Shows DSC Resources' {
+        $expectedDSCResources = 'AdvancedAppSettings', 'AppExecutionAliases'
+        $availableDSCResources = (Get-DscResource -Module Microsoft.Windows.Setting.Apps).Name
+        $availableDSCResources.Count | Should -Be 2
+        $availableDSCResources | Where-Object { $expectedDSCResources -notcontains $_ } | Should -BeNullOrEmpty -ErrorAction Stop
+    }
+}
+
+Describe 'AdvancedAppSettings' {
+    It 'Set app source preference' {
+        $desiredState = @{
+            AppSourcePreference   = 'StoreOnly'
+            ShareDeviceExperience = 'Device'
+            ArchiveApp            = $false
+        }
+        Invoke-DscResource -Name AdvancedAppSettings -ModuleName Microsoft.Windows.Setting.Apps -Method Set -Property $desiredState
+
+        $finalState = Invoke-DscResource -Name AdvancedAppSettings -ModuleName Microsoft.Windows.Setting.Apps -Method Get -Property @{}
+        $finalState.AppSourcePreference | Should -Be 'StoreOnly'
+        $finalState.ShareDeviceExperience | Should -Be 'Device'
+        $finalState.ArchiveApp | Should -Be $false
+    }
+}


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-dsc).
- [x] This pull request is related to an issue.

-----

This PR addresses starts to address issue #98 . The following DSC resources are introduced:

- `AdvancedAppSettings`
- `AppExecutionAliases`

> [!NOTE]
> Tests for app execution aliases are excluded, as I'm not expecting Windows Server 2022 to contain any App Installers.