### PR TITLE
Add securityContext to configuration samples

### DIFF
--- a/.config/configuration.winget
+++ b/.config/configuration.winget
@@ -9,7 +9,6 @@ properties:
       id: install-git
       directives:
         description: Install Git # Although the user probably already has git installed, it's possible that they don't
-        allowPrerelease: true
       settings:
         id: Git.Git
         source: winget
@@ -20,7 +19,6 @@ properties:
       id: install-github-cli
       directives:
         description: Install GitHub CLI
-        allowPrerelease: true
         securityContext: elevated
       settings:
         id: GitHub.cli
@@ -46,7 +44,6 @@ properties:
       id: install-vs-code
       directives:
         description: Install Microsoft Visual Studio Code
-        allowPrerelease: true
       settings:
         id: Microsoft.VisualStudioCode
         source: winget
@@ -88,7 +85,7 @@ properties:
       id: install-powershell
       directives:
         description: Install PowerShell
-        allowPrerelease: true
+        securityContext: elevated
       settings:
         id: Microsoft.PowerShell
         source: winget

--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -73,7 +73,7 @@ configuration:
               - filesMatchPattern:
                   pattern: ^\.?[\\\/]?.github[\\\/].*
               - filesMatchPattern:
-                  pattern: ^\.?[\\\/]?.configurations[\\\/].*
+                  pattern: ^\.?[\\\/]?.config[\\\/].*
               - filesMatchPattern:
                   pattern: ^\.?[\\\/]?.vscode[\\\/].*
               - filesMatchPattern:

--- a/samples/DscResources/Microsoft.WindowsSandbox.DSC/README.md
+++ b/samples/DscResources/Microsoft.WindowsSandbox.DSC/README.md
@@ -6,7 +6,7 @@ The [Microsoft.WindowsSandbox.DSC](https://www.powershellgallery.com/packages/Mi
 
 Prior to running this configuration, users should be on either Windows PRO or Windows enterprise. The "Windows Sandbox" optional feature also needs to be enabled.
 
-The "full.sandbox.winget" configuration is not fully capable of verifying the Windows SKU or enabling Windows optional features via the WinGet CLI (and subsequently Dev Home). The Windows optional features can be enabled in a configuration when run via the Microsoft.WinGet.Configuration.
+The "full.sandbox.winget" configuration is not fully capable of verifying the Windows SKU or enabling Windows optional features via the WinGet CLI. The Windows optional features can be enabled in a configuration when run via the Microsoft.WinGet.Configuration.
 
 The "full.sandbox.winget" configuration can be run via the Microsoft.WinGet.Configuration module.
 
@@ -26,19 +26,14 @@ get-WinGetConfiguration -File full.sandbox.winget | Invoke-WinGetConfiguration
 
 The following two options are available for running a WinGet Configuration file on your device.
 
-### 1. Windows Package Manager
+### 1. File Explorer
 
 1. Download the `sandbox.winget` file to your computer.
-1. Open your Windows Start Menu, search and launch "_Windows Terminal_".
-1. Type the following: `CD <C:\Users\User\Download>`
-1. Type the following: `winget configure --file .\sandbox.winget`
+2. Double-click the `sandbox.winget` file.
 
-### 2. Dev Home
+### 2. Windows Package Manager
 
 1. Download the `sandbox.winget` file to your computer.
-1. Open your Windows Start Menu, search and launch "_Dev Home_".
-1. Select the _Machine Configuration_ button on the left side navigation.
-1. Select the _Configuration file_ button
-1. Locate and open the WinGet Configuration file downloaded in "step 1".
-1. Select the "I agree and want to continue" checkbox.
-1. Select the "Set up as admin" button.
+2. Open your Windows Start Menu, search and launch "_Windows Terminal_".
+3. Type the following: `CD <C:\Users\User\Download>`
+4. Type the following: `winget configure --file .\sandbox.winget`

--- a/samples/README.md
+++ b/samples/README.md
@@ -2,13 +2,17 @@
 
 ## Using the sample configurations
 
-Download the \*.winget files to your local system. They can be executed in Dev Home via the "Machine configuration" section. They can also be executed by running `winget configure <path to configuration file>`.
+Download the \*.winget files to your local system. They can be executed by double-clicking on the file from file explorer. They can also be executed by running `winget configure <path to configuration file>`.
 
-Several DSC resources may require running in administrator mode. If the configuration is leveraging the [WinGet DSC resource](https://www.powershellgallery.com/packages/Microsoft.WinGet.DSC) to install packages, there are also limitations in some cases specific to the installers that may either require or prohibit installation in administrative context.
+Some DSC resources may need to run with administrator privileges.
+The `securityContext: elevated` field under the `directives` section of a resource indicates this requirement.
+When set to `elevated`, WinGet will prompt for **one** UAC approval at the start of the configuration. WinGet will then launch two processes: one that runs resources with elevated privileges and another that runs resources with the current user's privileges.
+
+If the configuration is leveraging the [WinGet DSC resource](https://www.powershellgallery.com/packages/Microsoft.WinGet.DSC) to install packages, there are also limitations in some cases specific to the installers that may either require or prohibit installation in administrative context.
 
 ### GitHub projects (Repositories)
 
-Sample configurations have been provided for various GitHub repositories. These configurations ideally should be placed in a `.configurations` folder in the root of the project directory. Some DSC resources may have parameters that allow you to pass in a relative file path. The reserved variable `$(WinGetConfigRoot)` can be used to specify the full path of the configuration file. An example of how to use that variable with a relative file path is shown below:
+Sample configurations have been provided for various GitHub repositories. These configurations ideally should be placed in a `.config` folder in the root of the project directory. Some DSC resources may have parameters that allow you to pass in a relative file path. The reserved variable `$(WinGetConfigRoot)` can be used to specify the full path of the configuration file. An example of how to use that variable with a relative file path is shown below:
 
 ```yaml
 - resource: Microsoft.VisualStudio.DSC/VSComponents
@@ -16,6 +20,7 @@ Sample configurations have been provided for various GitHub repositories. These 
   directives:
     description: Install required VS workloads from .vsconfig file
     allowPrerelease: true
+    securityContext: elevated
   settings:
     productId: Microsoft.VisualStudio.Product.Community
     channelId: VisualStudio.17.Release

--- a/samples/Repositories/PowerShell/PowerShell/configuration.winget
+++ b/samples/Repositories/PowerShell/PowerShell/configuration.winget
@@ -5,13 +5,14 @@ properties:
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
         description: Install Visual Studio 2022 Community
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Community
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
         description: Install .NET SDK 8.0-preview
-        allowPrerelease: true
+        securityContext: elevated
       settings:
         id: Microsoft.DotNet.SDK.Preview
         source: winget

--- a/samples/Repositories/apache/echarts/configuration.winget
+++ b/samples/Repositories/apache/echarts/configuration.winget
@@ -6,7 +6,7 @@ properties:
       id: npm
       directives:
         description: Install Node.js
-        allowPrerelease: true
+        securityContext: elevated
       settings:
         id: OpenJS.NodeJS
         source: winget

--- a/samples/Repositories/dotnet/aspnetcore/configuration.winget
+++ b/samples/Repositories/dotnet/aspnetcore/configuration.winget
@@ -5,18 +5,21 @@ properties:
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
         description: Install Microsoft Open JDK 17
+        securityContext: elevated
       settings:
         id: Microsoft.OpenJDK.17
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
         description: Install Yarn
+        securityContext: elevated
       settings:
         id: Yarn.Yarn
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
         description: Install Node.js
+        securityContext: elevated
       settings:
         id: OpenJS.NodeJS
         source: winget
@@ -24,6 +27,7 @@ properties:
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 Community
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Community
         source: winget
@@ -33,6 +37,7 @@ properties:
       directives:
         description: Install required VS workloads
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Community
         channelId: VisualStudio.17.Release

--- a/samples/Repositories/jquery/jquery/configuration.winget
+++ b/samples/Repositories/jquery/jquery/configuration.winget
@@ -6,7 +6,7 @@ properties:
       id: npm
       directives:
         description: Install Node version 8+
-        allowPrerelease: true
+        securityContext: elevated
       settings:
         id: OpenJS.NodeJS
         source: winget

--- a/samples/Repositories/microsoft/PowerToys/configuration.winget
+++ b/samples/Repositories/microsoft/PowerToys/configuration.winget
@@ -6,12 +6,14 @@ properties:
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
+        securityContext: elevated
       settings:
         Ensure: Present
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 (any edition is OK)
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Community
         source: winget
@@ -21,6 +23,7 @@ properties:
       directives:
         description: Install required VS workloads
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Community
         channelId: VisualStudio.17.Release

--- a/samples/Repositories/microsoft/gdk/configuration.winget
+++ b/samples/Repositories/microsoft/gdk/configuration.winget
@@ -5,6 +5,7 @@ properties:
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 Community
+        securityContext: elevated
         module: Microsoft.WinGet.DSC
       settings:
         id: Microsoft.VisualStudio.2022.Community
@@ -17,6 +18,7 @@ properties:
         description: Install required VS workloads
         module: Microsoft.VisualStudio.DSC
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Community
         channelId: VisualStudio.17.Release
@@ -29,6 +31,7 @@ properties:
       directives:
         description: Install Microsoft GDK
         module: Microsoft.WinGet.DSC
+        securityContext: elevated
       settings:
         id: Microsoft.Gaming.GDK
         source: winget

--- a/samples/Repositories/microsoft/terminal/configuration.winget
+++ b/samples/Repositories/microsoft/terminal/configuration.winget
@@ -6,24 +6,28 @@ properties:
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
+        securityContext: elevated
       settings:
         Ensure: Present
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
         description: Install PowerShell 7
+        securityContext: elevated
       settings:
         id: Microsoft.PowerShell
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
         description: Install Windows 11 (10.0.22621.0) SDK
+        securityContext: elevated
       settings:
-        id: Microsoft.WindowsSDK
+        id: Microsoft.WindowsSDK.10.0.22621
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 (any edition is OK)
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Community
         source: winget
@@ -33,6 +37,7 @@ properties:
       directives:
         description: Install required VS workloads
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Community
         channelId: VisualStudio.17.Release
@@ -40,7 +45,7 @@ properties:
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
         description: Install .NET Framework Targeting Pack 4.8
-        allowPrerelease: true
+        securityContext: elevated
       settings:
         id: Microsoft.DotNet.Framework.DeveloperPack_4
         source: winget

--- a/samples/Repositories/microsoft/vscode/configuration.winget
+++ b/samples/Repositories/microsoft/vscode/configuration.winget
@@ -6,6 +6,7 @@ properties:
       id: npm
       directives:
         description: Install NodeJS version >=16.17.x and <17
+        securityContext: elevated
       settings:
         id: OpenJS.NodeJS.LTS
         version: "16.20.0"
@@ -31,6 +32,7 @@ properties:
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 (any edition is OK)
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.BuildTools
         source: winget
@@ -40,6 +42,7 @@ properties:
       directives:
         description: Install required VS workloads
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.BuildTools
         channelId: VisualStudio.17.Release

--- a/samples/Repositories/microsoft/winget-cli-restsource/configuration.winget
+++ b/samples/Repositories/microsoft/winget-cli-restsource/configuration.winget
@@ -6,12 +6,14 @@ properties:
       id: vsPackage
       directives:
         description: Install Visual Studio 2019 (any edition is OK)
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2019.Professional
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
         description: Install .NET SDK 3.1
+        securityContext: elevated
       settings:
         id: Microsoft.DotNet.SDK.3_1
         source: winget
@@ -21,6 +23,7 @@ properties:
       directives:
         description: Install required VS workloads
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Professional
         channelId: VisualStudio.16.Release

--- a/samples/Repositories/microsoft/winget-cli/configuration.winget
+++ b/samples/Repositories/microsoft/winget-cli/configuration.winget
@@ -6,12 +6,14 @@ properties:
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
+        securityContext: elevated
       settings:
         Ensure: Present
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 (any edition is OK)
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Community
         source: winget
@@ -21,6 +23,7 @@ properties:
       directives:
         description: Install required VS workloads from project .vsconfig file
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Community
         channelId: VisualStudio.17.Release

--- a/samples/Repositories/microsoft/winget-create/configuration.winget
+++ b/samples/Repositories/microsoft/winget-create/configuration.winget
@@ -6,6 +6,7 @@ properties:
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 Community
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Community
         source: winget
@@ -15,6 +16,7 @@ properties:
       directives:
         description: Install required VS workloads
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Community
         channelId: VisualStudio.17.Release

--- a/samples/Repositories/redux/reduxjs/configuration.winget
+++ b/samples/Repositories/redux/reduxjs/configuration.winget
@@ -6,6 +6,7 @@ properties:
       id: npm
       directives:
         description: Install Node >=v18.10
+        securityContext: elevated
       settings:
         id: OpenJS.NodeJS
         source: winget

--- a/samples/Repositories/tastejs/todomvc/configuration.winget
+++ b/samples/Repositories/tastejs/todomvc/configuration.winget
@@ -6,6 +6,7 @@ properties:
       id: npm
       directives:
         description: Install Node version 14+
+        securityContext: elevated
       settings:
         id: OpenJS.NodeJS
         source: winget

--- a/samples/Repositories/videojs/videojs/configuration.winget
+++ b/samples/Repositories/videojs/videojs/configuration.winget
@@ -6,6 +6,7 @@ properties:
       id: npm
       directives:
         description: Install Node
+        securityContext: elevated
       settings:
         id: OpenJS.NodeJS
         source: winget

--- a/samples/Templates/Introduction/C#/README.md
+++ b/samples/Templates/Introduction/C#/README.md
@@ -1,6 +1,6 @@
 # Understanding WinGet Configuration Files
 
-This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) (_configuration.winget_) that will work with the WinGet command line interface (`winget configure --file [path: configuration.winget]`) or can be run using [Microsoft Dev Home](https://learn.microsoft.com/windows/dev-home/) Device Configuration.
+This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) (_configuration.winget_) that will work with the WinGet command line interface (`winget configure --file [path: configuration.winget]`) or can be run directly by double-clicking on the file.
 
 When run, the `configuration.winget` file will install the following list of applications:
 
@@ -14,23 +14,18 @@ The `configuration.winget` file will also enable [Developer Mode](https://learn.
 
 The following two options are available for running a WinGet Configuration file on your device.
 
-### 1. Windows Package Manager
+### 1. File Explorer
 
-1. Download the `configuration.winget` file to your computer.
-1. Open your Windows Start Menu, search and launch "_Windows Terminal_".
-1. Type the following: `CD <C:\Users\User\Download>`
-1. Type the following: `winget configure --file .\configuration.winget`
+1. Download the `sandbox.winget` file to your computer.
+2. Double-click the `sandbox.winget` file.
 
-### 2. Dev Home
+### 2. Windows Package Manager
 
-1. Download the `configuration.winget` file to your computer.
-1. Open your Windows Start Menu, search and launch "_Dev Home_".
-1. Select the _Machine Configuration_ button on the left side navigation.
-1. Select the _Configuration file_ button
-1. Locate and open the WinGet Configuration file downloaded in "step 1".
-1. Select the "I agree and want to continue" checkbox.
-1. Select the "Set up as admin" button.
+1. Download the `sandbox.winget` file to your computer.
+2. Open your Windows Start Menu, search and launch "_Windows Terminal_".
+3. Type the following: `CD <C:\Users\User\Download>`
+4. Type the following: `winget configure --file .\sandbox.winget`
 
 ## Issues with Configuration file
 
-If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/devhome/issues/new/choose), or [search existing issues](https://github.com/microsoft/devhome/issues) for a preexisting issue filed by another user.
+If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/winget-dsc/issues/new/choose), or [search existing issues](https://github.com/microsoft/winget-dsc/issues) for a preexisting issue filed by another user.

--- a/samples/Templates/Introduction/C#/configuration.winget
+++ b/samples/Templates/Introduction/C#/configuration.winget
@@ -19,6 +19,7 @@ properties:
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
+        securityContext: elevated
       settings:
         Ensure: Present
     - resource: Microsoft.WinGet.DSC/WinGetPackage
@@ -32,6 +33,7 @@ properties:
       id: Visual Studio
       directives:
         description: Install Visual Studio 2022 Community
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Community
         source: winget
@@ -42,6 +44,7 @@ properties:
       directives:
         description: Install required VS Workloads (ManagedDesktop)
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Community
         channelId: VisualStudio.17.Release
@@ -54,6 +57,7 @@ properties:
       directives:
         description: Install required VS Workloads (Universal)
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Community
         channelId: VisualStudio.17.Release

--- a/samples/Templates/Introduction/C++/README.md
+++ b/samples/Templates/Introduction/C++/README.md
@@ -1,6 +1,6 @@
 # Understanding WinGet Configuration Files
 
-This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) (_configuration.winget_) that will work with the WinGet command line interface (`winget configure --file [path: configuration.winget]`) or can be run using [Microsoft Dev Home](https://learn.microsoft.com/windows/dev-home/) Device Configuration.
+This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) (_configuration.winget_) that will work with the WinGet command line interface (`winget configure --file [path: configuration.winget]`) or can be run directly by double-clicking on the file.
 
 When run, the `configuration.winget` file will install the following list of applications:
 
@@ -14,23 +14,18 @@ The `configuration.winget` file will also enable [Developer Mode](https://learn.
 
 The following two options are available for running a WinGet Configuration file on your device.
 
-### 1. Windows Package Manager
+### 1. File Explorer
 
-1. Download the `configuration.winget` file to your computer.
-1. Open your Windows Start Menu, search and launch "_Windows Terminal_".
-1. Type the following: `CD <C:\Users\User\Download>`
-1. Type the following: `winget configure --file .\configuration.winget`
+1. Download the `sandbox.winget` file to your computer.
+2. Double-click the `sandbox.winget` file.
 
-### 2. Dev Home
+### 2. Windows Package Manager
 
-1. Download the `configuration.winget` file to your computer.
-1. Open your Windows Start Menu, search and launch "_Dev Home_".
-1. Select the _Machine Configuration_ button on the left side navigation.
-1. Select the _Configuration file_ button
-1. Locate and open the WinGet Configuration file downloaded in "step 1".
-1. Select the "I agree and want to continue" checkbox.
-1. Select the "Set up as admin" button.
+1. Download the `sandbox.winget` file to your computer.
+2. Open your Windows Start Menu, search and launch "_Windows Terminal_".
+3. Type the following: `CD <C:\Users\User\Download>`
+4. Type the following: `winget configure --file .\sandbox.winget`
 
 ## Issues with Configuration file
 
-If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/devhome/issues/new/choose), or [search existing issues](https://github.com/microsoft/devhome/issues) for a preexisting issue filed by another user.
+If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/winget-dsc/issues/new/choose), or [search existing issues](https://github.com/microsoft/winget-dsc/issues) for a preexisting issue filed by another user.

--- a/samples/Templates/Introduction/C++/configuration.winget
+++ b/samples/Templates/Introduction/C++/configuration.winget
@@ -21,6 +21,7 @@ properties:
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
+        securityContext: elevated
       settings:
         Ensure: Present
     - resource: Microsoft.WinGet.DSC/WinGetPackage
@@ -34,6 +35,7 @@ properties:
       id: VisualStudio
       directives:
         description: Install Visual Studio 2022 Community
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Community
         source: winget
@@ -44,6 +46,7 @@ properties:
       directives:
         description: Install required VS Workloads (NativeDesktop)
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Community
         channelId: VisualStudio.17.Release
@@ -57,6 +60,7 @@ properties:
       directives:
         description: Install required VS Workloads (Universal)
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Community
         channelId: VisualStudio.17.Release
@@ -68,6 +72,7 @@ properties:
         - VisualStudio
       directives:
         description: Install Windows SDK
+        securityContext: elevated
       settings:
         id: Microsoft.WindowsSDK.10.0.22621
         source: winget

--- a/samples/Templates/Introduction/JavaScript.NodeJS/README.md
+++ b/samples/Templates/Introduction/JavaScript.NodeJS/README.md
@@ -1,6 +1,6 @@
 # Understanding WinGet Configuration Files
 
-This folder contains a WinGet Configuration File (_configuration.winget_) that will work with the Windows Package Manager command line interface (`winget configure --file [path: configuration.winget]`) or can be run using Microsoft Dev Home Device Configuration.
+This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) (_configuration.winget_) that will work with the WinGet command line interface (`winget configure --file [path: configuration.winget]`) or can be run directly by double-clicking on the file.
 
 When run, the `configuration.winget` file will install the following list of applications:
 
@@ -12,19 +12,14 @@ The `configuration.winget` file will also enable [Developer Mode](https://learn.
 
 ## How to use the WinGet Configuration File
 
-### Windows Package Manager
+### 1. File Explorer
 
-1. Download the `configuration.winget` file to your computer.
-1. Open your Windows Start Menu, search and launch "_Windows Terminal_".
-1. Type the following: `CD [C:\Users\User\Download]`
-1. Type the following: `winget configure --file .\configuration.winget`
+1. Download the `sandbox.winget` file to your computer.
+2. Double-click the `sandbox.winget` file.
 
-### Dev Home
+### 2. Windows Package Manager
 
-1. Download the `configuration.winget` file to your computer.
-1. Open your Windows Start Menu, search and launch "_Dev Home_".
-1. Select the _Machine Configuration_ button on the left side navigation.
-1. Select the _Configuration file_ button
-1. Locate and open the WinGet Configuration file downloaded in "step 1".
-1. Select the "I agree and want to continue" checkbox.
-1. Select the "Set up as admin" button.
+1. Download the `sandbox.winget` file to your computer.
+2. Open your Windows Start Menu, search and launch "_Windows Terminal_".
+3. Type the following: `CD <C:\Users\User\Download>`
+4. Type the following: `winget configure --file .\sandbox.winget`

--- a/samples/Templates/Introduction/JavaScript.NodeJS/configuration.winget
+++ b/samples/Templates/Introduction/JavaScript.NodeJS/configuration.winget
@@ -21,6 +21,7 @@ properties:
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
+        securityContext: elevated
       settings:
         Ensure: Present
     - resource: Microsoft.WinGet.DSC/WinGetPackage
@@ -41,6 +42,7 @@ properties:
       id: Visual Studio
       directives:
         description: Install Visual Studio 2022 Community
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Community
         source: winget
@@ -51,6 +53,7 @@ properties:
       directives:
         description: Install required VS Workloads (NodeJS)
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Community
         channelId: VisualStudio.17.Release
@@ -63,6 +66,7 @@ properties:
       directives:
         description: Install required VS Workloads (Universal)
         allowPrerelease: true
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Community
         channelId: VisualStudio.17.Release

--- a/samples/Templates/Introduction/PowerShell/README.md
+++ b/samples/Templates/Introduction/PowerShell/README.md
@@ -1,6 +1,6 @@
 # Understanding WinGet Configuration Files
 
-This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) (_configuration.winget_) that will work with the WinGet command line interface (`winget configure --file [path: configuration.winget]`) or can be run using [Microsoft Dev Home](https://learn.microsoft.com/windows/dev-home/) Device Configuration.
+This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) (_configuration.winget_) that will work with the WinGet command line interface (`winget configure --file [path: configuration.winget]`) or can be run directly by double-clicking on the file.
 
 When run, the `configuration.winget` file will install the following list of applications:
 
@@ -10,23 +10,18 @@ When run, the `configuration.winget` file will install the following list of app
 
 The following two options are available for running a WinGet Configuration file on your device.
 
-### 1. Windows Package Manager
+### 1. File Explorer
 
-1. Download the `configuration.winget` file to your computer.
-1. Open your Windows Start Menu, search and launch "_Windows Terminal_".
-1. Type the following: `CD <C:\Users\User\Download>`
-1. Type the following: `winget configure --file .\configuration.winget`
+1. Download the `sandbox.winget` file to your computer.
+2. Double-click the `sandbox.winget` file.
 
-### 2. Dev Home
+### 2. Windows Package Manager
 
-1. Download the `configuration.winget` file to your computer.
-1. Open your Windows Start Menu, search and launch "_Dev Home_".
-1. Select the _Machine Configuration_ button on the left side navigation.
-1. Select the _Configuration file_ button
-1. Locate and open the WinGet Configuration file downloaded in "step 1".
-1. Select the "I agree and want to continue" checkbox.
-1. Select the "Set up as admin" button.
+1. Download the `sandbox.winget` file to your computer.
+2. Open your Windows Start Menu, search and launch "_Windows Terminal_".
+3. Type the following: `CD <C:\Users\User\Download>`
+4. Type the following: `winget configure --file .\sandbox.winget`
 
 ## Issues with Configuration file
 
-If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/devhome/issues/new/choose), or [search existing issues](https://github.com/microsoft/devhome/issues) for a preexisting issue filed by another user.
+If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/winget-dsc/issues/new/choose), or [search existing issues](https://github.com/microsoft/winget-dsc/issues) for a preexisting issue filed by another user.

--- a/samples/Templates/Introduction/Python3.12/README.md
+++ b/samples/Templates/Introduction/Python3.12/README.md
@@ -1,6 +1,6 @@
 # Understanding WinGet Configuration Files
 
-This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) (_configuration.winget_) that will work with the WinGet command line interface (`winget configure --file [path: configuration.winget]`) or can be run using [Microsoft Dev Home](https://learn.microsoft.com/windows/dev-home/) Device Configuration.
+This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) (_configuration.winget_) that will work with the WinGet command line interface (`winget configure --file [path: configuration.winget]`) or can be run directly by double-clicking on the file.
 
 When run, the `configuration.winget` file will install the following list of applications:
 
@@ -15,23 +15,18 @@ The `configuration.winget` file will also enable [Developer Mode](https://learn.
 
 The following two options are available for running a WinGet Configuration file on your device.
 
-### 1. Windows Package Manager
+### 1. File Explorer
 
-1. Download the `configuration.winget` file to your computer.
-1. Open your Windows Start Menu, search and launch "_Windows Terminal_".
-1. Type the following: `CD <C:\Users\User\Download>`
-1. Type the following: `winget configure --file .\configuration.winget`
+1. Download the `sandbox.winget` file to your computer.
+2. Double-click the `sandbox.winget` file.
 
-### 2. Dev Home
+### 2. Windows Package Manager
 
-1. Download the `configuration.winget` file to your computer.
-1. Open your Windows Start Menu, search and launch "_Dev Home_".
-1. Select the _Machine Configuration_ button on the left side navigation.
-1. Select the _Configuration file_ button
-1. Locate and open the WinGet Configuration file downloaded in "step 1".
-1. Select the "I agree and want to continue" checkbox.
-1. Select the "Set up as admin" button.
+1. Download the `sandbox.winget` file to your computer.
+2. Open your Windows Start Menu, search and launch "_Windows Terminal_".
+3. Type the following: `CD <C:\Users\User\Download>`
+4. Type the following: `winget configure --file .\sandbox.winget`
 
 ## Issues with Configuration file
 
-If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/devhome/issues/new/choose), or [search existing issues](https://github.com/microsoft/devhome/issues) for a preexisting issue filed by another user.
+If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/winget-dsc/issues/new/choose), or [search existing issues](https://github.com/microsoft/winget-dsc/issues) for a preexisting issue filed by another user.

--- a/samples/Templates/Introduction/Python3.12/configuration.winget
+++ b/samples/Templates/Introduction/Python3.12/configuration.winget
@@ -19,6 +19,7 @@ properties:
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
+        securityContext: elevated
       settings:
         Ensure: Present
     - resource: Microsoft.WinGet.DSC/WinGetPackage


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-dsc).
- [ ] This pull request is related to an issue.

### Summary of changes

- Removed `allowPrerelease: true` from `Microsoft.WinGet.DSC/WinGetPackage` resource as it's GA now
- Added `securityContext: elevated` for all examples using `Microsoft.Windows.Developer/DeveloperMode` & `Microsoft.VisualStudio.DSC/VSComponents`. For installation of WinGet packages that require elevation, added this field too in their resouce
- Removed mentions of Dev Home and replaced them with guidance of directly launching the file by "double-clicking". The places where the devhome repo was mentioned, I changed it to reference the winget-dsc repo now
- Update `.config` as the new conventional file location for Winget config files instead of `.configurations`


-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-dsc/pull/163)