### PR TITLE
Fix PythonPip3Dsc capabilities list to be correct camelCasing

### DIFF
--- a/resources/PythonPip3Dsc/PythonPip3Dsc.psd1
+++ b/resources/PythonPip3Dsc/PythonPip3Dsc.psd1
@@ -119,7 +119,7 @@
 
             # External dependent modules of this module
             # ExternalModuleDependencies = @()
-            DscCapabilities = @('Get', 'Set', 'Test', 'Export', 'WhatIf')
+            DscCapabilities = @('get', 'set', 'test', 'export', 'whatIf')
 
         } # End of PSData hashtable
 


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-dsc).
- [x] This pull request is related to an issue.

-----

`dsc resource list` gives a warning because the list of capabilities in this module manifest don't match what `dsc` expects because JSON is case-sensitive.   This change fixes the casing to be camelCase.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-dsc/pull/193)