### PR TITLE
Change TaskbarAlignment "Center" to "Middle"

### DIFF
--- a/resources/Microsoft.Windows.Settings/Microsoft.Windows.Settings.psm1
+++ b/resources/Microsoft.Windows.Settings/Microsoft.Windows.Settings.psm1
@@ -108,11 +108,11 @@ class WindowsSettings {
 
     [string] GetTaskbarAlignment() {
         if (-not(DoesRegistryKeyPropertyExist -Path $global:ExplorerRegistryPath -Name $this.TaskbarAl)) {
-            return "Middle"
+            return "Center"
         }
 
         $value = [int](Get-ItemPropertyValue -Path $global:ExplorerRegistryPath -Name $this.TaskbarAl)
-        return $value -eq 0 ? "Left" : "Middle"
+        return $value -eq 0 ? "Left" : "Center"
     }
 
     [string] GetAppColorMode() {
@@ -124,7 +124,7 @@ class WindowsSettings {
         if ($appsUseLightModeValue -eq 0) {
             return "Dark"
         }
-        
+
         return "Light"
     }
 
@@ -197,7 +197,7 @@ public class NativeMethods {
         uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
 }
 "@
-    
+
     # Constants
     $HWND_BROADCAST = [IntPtr]0xffff
     $WM_SETTINGCHANGE = 0x001A

--- a/samples/DscResources/Microsoft.Windows.Settings/DefaultWindowsSettings.winget
+++ b/samples/DscResources/Microsoft.Windows.Settings/DefaultWindowsSettings.winget
@@ -16,5 +16,5 @@ properties:
         AppColorMode: Light
         DeveloperMode: false
         SystemColorMode: Light
-        TaskbarAlignment: Middle
+        TaskbarAlignment: Center
   configurationVersion: 0.2.0

--- a/samples/DscResources/Microsoft.Windows.Settings/DefaultWindowsSettings.winget
+++ b/samples/DscResources/Microsoft.Windows.Settings/DefaultWindowsSettings.winget
@@ -16,5 +16,5 @@ properties:
         AppColorMode: Light
         DeveloperMode: false
         SystemColorMode: Light
-        TaskbarAlignment: Center
+        TaskbarAlignment: Middle
   configurationVersion: 0.2.0


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-dsc).
- [ ] This pull request is related to an issue.

~~"Center" value only works at the moment because of #199. If we do some work to tackle #199, the sample would stop working. This PR just changes the value to what the resource currently has logic written against~~

Since "Center" is the value shown in Windows settings, use "Center" string instead of "Middle" in the resource. It doesn't make a different at the moment because of #199, but when we do tackle that issue, the string should be the proper one to use so that the [sample](https://github.com/microsoft/winget-dsc/blob/6e073871037e3719e2a0ce07741892854508d89b/samples/DscResources/Microsoft.Windows.Settings/DefaultWindowsSettings.winget#L19) doesn't break

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-dsc/pull/200)