### PR TITLE
Escape quotation marks in user.name using PowerShell syntax

### DIFF
--- a/resources/GitDsc/GitDsc.psm1
+++ b/resources/GitDsc/GitDsc.psm1
@@ -205,7 +205,7 @@ class GitConfigUserName {
         }
 
         if ($this.Ensure -eq [Ensure]::Present) {
-            $configArgs = ConstructGitConfigUserArguments -Arguments "user.name '$($this.UserName)'" -ConfigLocation $this.ConfigLocation
+            $configArgs = ConstructGitConfigUserArguments -Arguments "user.name `"$($this.UserName)`"" -ConfigLocation $this.ConfigLocation
         }
         else {
             $configArgs = ConstructGitConfigUserArguments -Arguments '--unset user.name' -ConfigLocation $this.ConfigLocation


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-dsc).
- [x] This pull request is related to an issue.

-----

This is related to #43, which was previously closed, but seems to persist in my case. The previous solution in #44 was to use single quotes. That wasn't working with DSCv3 on my computer. I'm requesting this change that uses the backtick operator to escape double quotes around the user name. This should also avoid problems with users who have a single quote in their name (e.g. "O'Malley").