### PR TITLE
Show module name+version in publish pipeline name

### DIFF
--- a/pipelines/azure-pipelines.publish.yml
+++ b/pipelines/azure-pipelines.publish.yml
@@ -1,5 +1,5 @@
 # winget-dsc pipeline to publish module artifacts
-name: '$(Build.DefinitionName)-$(Build.DefinitionVersion)-$(Date:yyyyMMdd)-$(Rev:r)'
+name: '$(Build.DefinitionName) - ${{ parameters.moduleName }} v${{ parameters.moduleVersion }}'
 
 trigger: none
 


### PR DESCRIPTION
To make it easier to identify what each pipeline run is publishing.

![image](https://github.com/user-attachments/assets/53334a0c-4d7c-49d4-a99f-15c1337dd7a1)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-dsc/pull/208)