### PR TITLE
Fix publish to gallery (attempt 5) 

### DIFF
--- a/pipelines/azure-pipelines.publish.yml
+++ b/pipelines/azure-pipelines.publish.yml
@@ -133,17 +133,12 @@ extends:
                 *.psd1
 
           steps:
-          - task: PowerShell@2
-            inputs:
-              targetType: 'inline'
-              script: |
-                $ConfirmPreference = 'None'
-                Install-PackageProvider -Name NuGet -Force -Scope CurrentUser
+          - powershell: |
+                Install-Module Microsoft.PowerShell.PSResourceGet -Force -Verbose
                 $moduleFolder = "$(System.DefaultWorkingDirectory)/ModuleToPublish/${{ parameters.moduleName }}"
                 Get-ChildItem -Path $moduleFolder -Recurse
                 $moduleFolderPath = (Resolve-Path $moduleFolder).Path
-                Publish-Module -Path $moduleFolderPath -Repository PSGallery -NuGetApiKey $env:api_key -verbose
-              pwsh: false
+                Publish-PSResource -Path $moduleFolderPath -Repository PSGallery -ApiKey $env:api_key -Verbose
             displayName: Publish ${{ parameters.moduleName }}
             env:
               api_key: $(DscSamplesNugetApiKey)


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [ ] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-dsc).
- [ ] This pull request is related to an issue.

-----

This pull request updates the PowerShell publishing step in the `pipelines/azure-pipelines.publish.yml` pipeline to use the newer `PSResourceGet` module and its associated `Publish-PSResource` cmdlet, replacing the deprecated `Publish-Module` approach.

**PowerShell module publishing modernization:**

* Switched from installing `NuGet` and using the legacy `Publish-Module` cmdlet to installing the `Microsoft.PowerShell.PSResourceGet` module and using the modern `Publish-PSResource` cmdlet for publishing modules to the PowerShell Gallery.