### PR TITLE
Adding F# + Rust WinGet config files for Microsoft Learn pages

### DIFF
--- a/.github/actions/spelling/expect/software.txt
+++ b/.github/actions/spelling/expect/software.txt
@@ -12,3 +12,6 @@ exa
 ripgrep
 rustup
 tokio
+lldb
+Rustlang
+vadimcn

--- a/samples/Configuration files/Learn tutorials/F#/README.md
+++ b/samples/Configuration files/Learn tutorials/F#/README.md
@@ -1,0 +1,16 @@
+# Install F# with Visual Studio
+
+This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) ([_learn_fsharp.winget_](./learn_fsharp.winget)) that will work with the WinGet command line interface (`winget configure --file [path: learn_fsharp.winget]`) or can be run directly by double-clicking on the file.
+
+When run, the [learn_fsharp.winget](./learn_fsharp.winget) file will install the following list of applications:
+
+- Microsoft Visual Studio Community 2022
+- Required Visual Studio workloads for ASP.NET and web development, which includes F# and .NET Core support for ASP.NET Core projects.
+
+If anything is already installed, the configuration file will skip that item.
+
+This configuration file is based on the [Install F#](https://learn.microsoft.com/en-us/dotnet/fsharp/get-started/install-fsharp) Microsoft Learn tutorial.
+
+## Issues with Configuration file
+
+If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/winget-dsc/issues/new/choose), or [search existing issues](https://github.com/microsoft/winget-dsc/issues) for a preexisting issue filed by another user.

--- a/samples/Configuration files/Learn tutorials/F#/learn_fsharp.winget
+++ b/samples/Configuration files/Learn tutorials/F#/learn_fsharp.winget
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+
+##########################################################################################################
+# This configuration will install the tools necessary to get started with F# development on Windows      #
+# Reference: https://learn.microsoft.com/en-us/dotnet/fsharp/get-started/install-fsharp                  #
+#                                                                                                        #
+# This will:                                                                                             #
+#     * Install Visual Studio Community 2022                                                             #
+#     * Install .NET web development and ASP.NET workloads to Visual Studio Community 2022               #
+#                                                                                                        #
+##########################################################################################################
+
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: VisualStudio
+      directives:
+        description: Install Visual Studio 2022 Community
+        securityContext: elevated
+      settings:
+        id: Microsoft.VisualStudio.2022.Community
+        source: winget
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      dependsOn:
+        - VisualStudio
+      directives:
+        description: Install ASP.NET and web development workloads
+        securityContext: elevated
+      settings:
+        productId: Microsoft.VisualStudio.Product.Community
+        channelId: VisualStudio.17.Release
+        components:
+          - Microsoft.VisualStudio.Workload.NetWeb
+          - Microsoft.VisualStudio.Component.AspNet45
+        includeRecommended: true
+  configurationVersion: 0.2.0

--- a/samples/Configuration files/Learn tutorials/Rust/README.md
+++ b/samples/Configuration files/Learn tutorials/Rust/README.md
@@ -1,0 +1,19 @@
+# Get started using Python on Windows for beginners
+
+This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) ([_learn_rust.winget_](./learn_rust.winget)) that will work with the WinGet command line interface (`winget configure --file [path: learn_rust.winget]`) or can be run directly by double-clicking on the file.
+
+When run, the [learn_rust.winget](./learn_rust.winget) file will install the following list of applications:
+
+- Visual Studio Code
+- CodeLLDB VS Code extension
+- Rust-analyzer VS Code extension
+- Rustup toolchain
+- Microsoft C and C++ (MSVC) toolchain
+
+If anything is already installed, the configuration file will skip that item.
+
+This configuration file is based on the Visual Studio Code workload in the [Set up your dev environment on Windows for Rust](https://learn.microsoft.com/en-us/windows/dev-environment/rust/setup#install-visual-studio-code) Microsoft Learn tutorial.
+
+## Issues with Configuration file
+
+If you experience an issue with running the provided WinGet Configuration file, you can submit a [new issue report](https://github.com/microsoft/winget-dsc/issues/new/choose), or [search existing issues](https://github.com/microsoft/winget-dsc/issues) for a preexisting issue filed by another user.

--- a/samples/Configuration files/Learn tutorials/Rust/README.md
+++ b/samples/Configuration files/Learn tutorials/Rust/README.md
@@ -1,4 +1,4 @@
-# Get started using Python on Windows for beginners
+# Get started using Rust on Windows for beginners
 
 This folder contains a [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/) (WinGet) [Configuration File](https://learn.microsoft.com/windows/package-manager/configuration/) ([_learn_rust.winget_](./learn_rust.winget)) that will work with the WinGet command line interface (`winget configure --file [path: learn_rust.winget]`) or can be run directly by double-clicking on the file.
 

--- a/samples/Configuration files/Learn tutorials/Rust/learn_rust.winget
+++ b/samples/Configuration files/Learn tutorials/Rust/learn_rust.winget
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+
+##########################################################################################################
+# This configuration will install the tools necessary to get started with Rust development on Windows    #
+# Reference: https://learn.microsoft.com/en-us/windows/dev-environment/rust/setup                        #
+#                                                                                                        #
+# This will:                                                                                             #
+#     * Install Visual Studio Code                                                                       #
+#     * Install rust-analyzer extension for Visual Studio Code                                           #
+#     * Install CodeLLDB extension for Visual Studio Code for debugging                                  #
+#     * Install Rustup toolchain                                                                         #
+#     * Install Microsoft C and C++ (MSVC) toolchain                                                     #
+#                                                                                                        #
+##########################################################################################################
+
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: vscode
+      directives:
+        description: Install Visual Studio Code
+      settings:
+        id: Microsoft.VisualStudioCode
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: Rustup
+      directives:
+        description: Install Rust toolchain
+      settings:
+        id: Rustlang.Rustup
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: Rust MSVC toolchain
+      directives:
+        description: Install Microsoft C and C++ (MSVC) toolchain
+      settings:
+        id: Rustlang.Rust.MSVC
+        source: winget
+    - resource: Microsoft.VSCode.Dsc/VSCodeExtension
+      id: rust-lang.rust-analyzer
+      directives:
+        description: Install rust-analyzer Visual Studio Code extension
+        allowPrerelease: true
+      dependsOn:
+        - vscode
+      settings:
+        name: rust-lang.rust-analyzer
+        exist: true
+    - resource: Microsoft.VSCode.Dsc/VSCodeExtension
+      id: vadimcn.vscode-lldb
+      directives:
+        description: Install CodeLLDB Visual Studio Code extension
+        allowPrerelease: true
+      dependsOn:
+        - vscode
+      settings:
+        name: vadimcn.vscode-lldb
+        exist: true
+
+  configurationVersion: 0.2.0

--- a/samples/Configuration files/Learn tutorials/Rust/learn_rust.winget
+++ b/samples/Configuration files/Learn tutorials/Rust/learn_rust.winget
@@ -25,7 +25,7 @@ properties:
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: Rustup
       directives:
-        description: Install Rust toolchain
+        description: Install Rustup toolchain
       settings:
         id: Rustlang.Rustup
         source: winget


### PR DESCRIPTION
Adding two new WinGet config files for Microsoft Learn paths. Validated the results of running the configurations, users should be able to start building in both languages after running the configs.

F#:
- Installing Visual Studio Community 2022
- Installing ASP.NET + web development workloads in Visual Studio

Rust:
- Installing Visual Studio Code
- Install rust-analyzer extension for Visual Studio Code 
- Install CodeLLDB extension for Visual Studio Code for debugging
- Install Rustup toolchain
- Install Microsoft C and C++ (MSVC) toolchain     


- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-dsc).
- [ ] This pull request is related to an issue.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-dsc/pull/224)