### PR TITLE
Move resource from Microsoft.Windows.Developer to Microsoft.Windows.Settings

### DIFF
--- a/resources/Microsoft.Windows.Settings/Microsoft.Windows.Settings.psd1
+++ b/resources/Microsoft.Windows.Settings/Microsoft.Windows.Settings.psd1
@@ -12,7 +12,8 @@
         'WindowsCapability',
         'PowerPlanSetting',
         'AdvancedNetworkSharingSetting',
-        'NetConnectionProfile'
+        'NetConnectionProfile',
+        'FirewallRule'
     )
     PrivateData          = @{
         PSData = @{
@@ -22,7 +23,8 @@
                 'PSDscResource_WindowsCapability',
                 'PSDscResource_PowerPlanSetting',
                 'PSDscResource_AdvancedNetworkSharingSetting',
-                'PSDscResource_NetConnectionProfile'
+                'PSDscResource_NetConnectionProfile',
+                'PSDscResource_FirewallRule'
             )
 
             # Prerelease string of this module


### PR DESCRIPTION
## Description
- Moved the following resources from Microsoft.Windows.Developer to Microsoft.Windows.Settings
  - WindowsCapability
  - PowerPlanSetting
  - AdvancedNetworkSharingSetting
  - NetConnectionProfile
  - FirewallRule

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [ ] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-dsc).
- [ ] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-dsc/pull/232)