### PR TITLE
Remove redundant `-Verbose` flag from Write-Verbose message in VSCodeExtension class

### DIFF
--- a/resources/Microsoft.VSCode.Dsc/Microsoft.VSCode.Dsc.psm1
+++ b/resources/Microsoft.VSCode.Dsc/Microsoft.VSCode.Dsc.psm1
@@ -450,7 +450,7 @@ class VSCodeExtension {
 
             return $finalState
         }
-        Write-Verbose -Message "Extension '$($this.Name)' with version '$($this.Version)' and pre-release '$($this.PreRelease)' does not exist." -Verbose
+        Write-Verbose -Message "Extension '$($this.Name)' with version '$($this.Version)' and pre-release '$($this.PreRelease)' does not exist."
         return [VSCodeExtension]@{
             Name       = $this.Name
             Version    = $this.Version


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-dsc).
- [x] This pull request is related to an issue.

-----

Fixes #240 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-dsc/pull/241)