### PR TITLE
Throw if `npm install` returns non-zero exit code

### DIFF
--- a/resources/NpmDsc/NpmDsc.psm1
+++ b/resources/NpmDsc/NpmDsc.psm1
@@ -17,8 +17,14 @@ function Invoke-Npm {
         [Parameter(Mandatory = $true)]
         [string]$Command
     )
+        $value = Invoke-Expression -Command "npm $Command"
 
-    return Invoke-Expression -Command "npm $Command"
+        if ($LASTEXITCODE -ne 0) {
+            $errors = Get-NpmErrorMessages -LogPath (GetNpmPath)
+            throw "Command 'npm $($Command.Trim())' failed: $($errors -join '; ')"
+        }
+
+        return $value
 }
 
 function Set-PackageDirectory {

--- a/tests/NpmDsc/NpmDsc.tests.ps1
+++ b/tests/NpmDsc/NpmDsc.tests.ps1
@@ -85,6 +85,10 @@ Describe 'NpmPackage' {
         $finalState.InDesiredState | Should -Be $true
     }
 
+    It 'Throws if npm returns non-zero exit code' -Skip:(!$IsWindows) {
+        { Invoke-Npm '!' } | Should -Throw "Command 'npm !' failed:*"
+    }
+
     It 'Performs whatif operation successfully' -Skip:(!$IsWindows) {
         $whatIfState = @{
             Name   = 'react'


### PR DESCRIPTION
Closes #251

```powershell
PS> invoke-DscResource -ModuleName NpmDsc -Name NpmPackage -Method set -Property @{ Name = 'mariozechner/pi-coding-agent'; Global = $true }
Exception: Command 'npm install mariozechner/pi-coding-agent -g' failed: error code 128; error An unknown git error occurred; error command git --no-replace-objects ls-remote ssh://git@github.com/mariozechner/pi-coding-agent.git; error git@github.com: Permission denied (publickey).; error fatal: Could not read from remote
repository.; error Please make sure you have the correct access rights; error and the repository exists.; error A complete log of this run can be found in: C:\Users\xxx\AppData\Local\npm-cache\_logs\2026-03-13T20_02_00_172Z-debug-0.log
```

---

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-dsc).
- [x] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-dsc/pull/252)