### PR TITLE
Update GitHub Projects page with Fork/Clone/Configure/F5 guidance and new projects

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -23,7 +23,7 @@ ephemoral
 esbenp
 Fancyzones
 formulahendry
-fynn
+fYnn
 gdk
 github
 gitversion
@@ -56,12 +56,12 @@ nonexistentpackage
 numpy
 NVM
 opencode
+onboarding
 opensource
 pkief
 powertoys
 prerel
 pscustomobject
-psobject
 Ptr
 pwa
 PWAs
@@ -72,7 +72,6 @@ restsource
 ritwickdey
 tastejs
 todomvc
-tokio
 toolsai
 toolset
 UAC
@@ -98,7 +97,6 @@ whatif
 wildcards
 winappdev
 Windo
-winget
 winui
 Wnd
 workaround
@@ -110,3 +108,4 @@ zhuangtongfa
 DWM
 tzautoupdate
 Usb
+Ynn

--- a/.github/actions/spelling/expect/software.txt
+++ b/.github/actions/spelling/expect/software.txt
@@ -11,7 +11,6 @@ msrustup
 exa
 ripgrep
 rustup
-tokio
 lldb
 Rustlang
 vadimcn

--- a/.github/actions/spelling/expect/software.txt
+++ b/.github/actions/spelling/expect/software.txt
@@ -11,6 +11,7 @@ msrustup
 exa
 ripgrep
 rustup
+tokio
 lldb
 Rustlang
 vadimcn

--- a/.github/actions/spelling/expect/usernames.txt
+++ b/.github/actions/spelling/expect/usernames.txt
@@ -1,2 +1,4 @@
 denelon
 Dobbeleer
+ryanlua
+victorfrye

--- a/.github/actions/spelling/expect/windows_terms.txt
+++ b/.github/actions/spelling/expect/windows_terms.txt
@@ -6,7 +6,7 @@ taskkill
 dotnet
 LASTEXITCODE
 DWord
-PSobject
+psobject
 winuser
 psm
 msrc

--- a/samples/GitHubProjects.md
+++ b/samples/GitHubProjects.md
@@ -1,9 +1,25 @@
 # GitHub Projects
 
-Below are known GitHub projects that use a WinGet configuration file that one can use to setup their environment for building the project. The [convention for the configuration file](https://learn.microsoft.com/windows/package-manager/configuration/create#file-naming-convention) is to name it `configuration.winget` and place it in a `.config` directory in the root of the project.
-The projects are listed in alphabetical order by their GitHub repository identifier. The list is not exhaustive and is meant to be a starting point for finding projects that use a WinGet configuration file. If you know of any other projects that use a WinGet configuration file, feel free to add them to the list.
+## Fork, Clone, Configure, F5
+
+WinGet configuration files enable a powerful onboarding pattern for open source projects: **Fork → Clone → Configure → F5**. Instead of following lengthy setup guides, new contributors can get a fully configured development environment with a single command:
+
+```powershell
+winget configure --file .config\configuration.winget --accept-configuration-agreements --disable-interactivity
+```
+
+This approach benefits open source projects by:
+
+- **Lowering the barrier to entry** — New contributors can go from zero to building and running the project in minutes, not hours. No more hunting for the right SDK version, missing dependencies, or misconfigured environment variables.
+- **Reducing onboarding friction** — Maintainers spend less time troubleshooting contributor setup issues and more time reviewing code. The configuration file *is* the setup documentation.
+- **Ensuring consistency** — Every contributor starts with the same tools, versions, and settings, eliminating "works on my machine" problems before they happen.
+- **Making contributions more accessible** — Developers who might otherwise be discouraged by a complex setup process can contribute to projects they care about.
+
+By placing a `configuration.winget` file in the `.config` directory at the root of your repository, you make your project instantly approachable to any developer on Windows. The [convention for the configuration file](https://learn.microsoft.com/windows/package-manager/configuration/create#file-naming-convention) is to name it `configuration.winget` and place it in a `.config` directory in the root of the project.
 
 ## Projects
+
+Below are known GitHub projects that use a WinGet configuration file that one can use to set up their environment for building the project. The projects are listed in alphabetical order by their GitHub repository identifier. The list is not exhaustive and is meant to be a starting point for finding projects that use a WinGet configuration file. If you know of any other projects that use a WinGet configuration file, feel free to add them to the list.
 
 - [dev-fynn/Winget-Repo](https://github.com/dev-fYnn/Winget-Repo/blob/master/.config/Winget-Repo_Dev.winget)
 - [dotnet/eShop](https://github.com/dotnet/eShop/blob/main/.config/configuration.vsCode.winget)
@@ -14,3 +30,9 @@ The projects are listed in alphabetical order by their GitHub repository identif
 - [microsoft/vscode](https://github.com/microsoft/vscode/blob/main/.config/configuration.winget)
 - [microsoft/winget-cli](https://github.com/microsoft/winget-cli/blob/master/.config/configuration.winget)
 - [microsoft/winget-create](https://github.com/microsoft/winget-create/blob/main/.config/configuration.winget)
+- [microsoft/winget-dsc](https://github.com/microsoft/winget-dsc/blob/main/.config/configuration.winget)
+- [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs/blob/master/.config/YamlCreate.winget)
+- [microsoft/winget-studio](https://github.com/microsoft/winget-studio/blob/main/.config/configuration.winget)
+- [posit-dev/positron](https://github.com/posit-dev/positron/blob/main/.config/configuration.winget)
+- [ryanlua/dotfiles](https://github.com/ryanlua/dotfiles/blob/main/.config/configuration.winget)
+- [victorfrye/dotfiles](https://github.com/victorfrye/dotfiles/blob/main/.config/configuration.winget)

--- a/samples/GitHubProjects.md
+++ b/samples/GitHubProjects.md
@@ -5,7 +5,7 @@
 WinGet configuration files enable a powerful onboarding pattern for open source projects: **Fork → Clone → Configure → F5**. Instead of following lengthy setup guides, new contributors can get a fully configured development environment with a single command:
 
 ```powershell
-winget configure --file .config\configuration.winget --accept-configuration-agreements --disable-interactivity
+winget configure --file .config\configuration.winget
 ```
 
 This approach benefits open source projects by:

--- a/samples/GitHubProjects.md
+++ b/samples/GitHubProjects.md
@@ -21,7 +21,7 @@ By placing a `configuration.winget` file in the `.config` directory at the root 
 
 Below are known GitHub projects that use a WinGet configuration file that one can use to set up their environment for building the project. The projects are listed in alphabetical order by their GitHub repository identifier. The list is not exhaustive and is meant to be a starting point for finding projects that use a WinGet configuration file. If you know of any other projects that use a WinGet configuration file, feel free to add them to the list.
 
-- [dev-fynn/Winget-Repo](https://github.com/dev-fYnn/Winget-Repo/blob/master/.config/Winget-Repo_Dev.winget)
+- [dev-fYnn/Winget-Repo](https://github.com/dev-fYnn/Winget-Repo/blob/master/.config/Winget-Repo_Dev.winget)
 - [dotnet/eShop](https://github.com/dotnet/eShop/blob/main/.config/configuration.vsCode.winget)
 - [JanDeDobbeleer/oh-my-posh](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/.config/configuration.winget)
 - [LibreOffice/core](https://github.com/LibreOffice/core/blob/master/.config/configuration.winget)


### PR DESCRIPTION
## Summary

Updates the GitHub Projects sample page with two improvements:

### Fork, Clone, Configure, F5

Added a new introductory section explaining the **Fork → Clone → Configure → F5** onboarding pattern that WinGet configuration files enable for open source projects. This section highlights:

- Lowering the barrier to entry for new contributors
- Reducing onboarding friction for maintainers
- Ensuring consistency across contributor environments
- Making contributions more accessible

### New Projects

Added 6 new projects discovered via GitHub code search (all verified to have WinGet configuration files in the conventional `.config/` directory):

| Project | Stars | Notes |
|---------|-------|-------|
| microsoft/winget-dsc | 140 | This repo |
| microsoft/winget-pkgs | 10,531 | Uses `YamlCreate.winget` |
| microsoft/winget-studio | 55 | WinGet Studio |
| posit-dev/positron | 4,106 | Next-gen data science IDE |
| ryanlua/dotfiles | — | Windows dotfiles |
| victorfrye/dotfiles | 3 | Windows dotfiles |

All projects are listed in alphabetical order per existing convention.

### Merge Order

This is PR **1 of 5** in a series of updates to the winget-dsc samples.

`#256` → #257 → #258 → #260 → #259