### PR TITLE
Replace Create your own section with WinGet Studio

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,4 +1,4 @@
-# DSC Samples
+# WinGet Configuration File Samples
 
 ## Understanding WinGet Configuration Files
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -28,4 +28,12 @@ Examples for a few specific DSC Resources are under the [DscResources](./DscReso
 
 ### Create your own
 
-Writing YAML is a pain. To help you get started creating your own, there is a [sample tool](https://github.com/microsoft/winget-create/blob/main/Tools/WingetCreateMakeDSC.ps1) for authoring in the winget-create repo. It currently only supports adding apps, but give it a try and contribute to make it better!
+[WinGet Studio](https://github.com/microsoft/winget-studio) is a graphical tool for creating, editing, and validating WinGet Configuration files. It provides a visual interface for adding DSC resources, configuring properties, and testing configurations without writing YAML by hand.
+
+To install WinGet Studio, run:
+
+```powershell
+winget install --id Microsoft.WinGetStudio.Experimental --source winget
+```
+
+For a step-by-step walkthrough, see the [Getting Started guide](https://github.com/microsoft/winget-studio/blob/main/docs/get-started/index.md).


### PR DESCRIPTION
## 📖 Description
Updates the README to replace the Create your own section's manual creation guidance with WinGet Studio guidance.

### Changed files
- `samples/README.md`

Created with GitHub Copilot assistance.

## 🔗 References
Resolves #268

## 🔍 Validation
- Reviewed `samples/README.md` to confirm the Create your own section now points to WinGet Studio.

## ✅ Checklist
- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
- [ ] Bug fix
- [ ] Feature
- [x] Task
