### PR TITLE
Fix policy bot bugs and modernize regex patterns

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -4,6 +4,8 @@ appwiz
 appx
 arp
 aspnetcore
+azp
+azurepipelines
 bbwe
 checkbox
 checkboxes

--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -56,11 +56,6 @@ configuration:
           - addLabel:
               label: Needs-Triage
       - description: >-
-          When a pull request is opened, if the files match DevOpsPipelineDefinitions/*
-          * Add a message to the author
-          * Assign to the author
-          * Add the "Needs-Author-Feedback" label
-      - description: >-
           When a PR is opened/updated, if the content is in a project folder and user is not repo admin
           * Add Project-File label
         if:

--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -119,10 +119,10 @@ configuration:
           - payloadType: Issue_Comment
           - or:
               - commentContains:
-                  pattern: '\/[a|A][z|Z][p|P] [r|R][u|U][n|N]'
+                  pattern: '(?in)\/azp run'
                   isRegex: True
               - commentContains:
-                  pattern: '\/[a|A][z|Z][u|U][r|R][e|E][p|P][i|I][p|P][e|E][l|L][i|I][n|N][e|E][s|S] [r|R][u|U][n|N]'
+                  pattern: '(?in)\/azurepipelines run'
                   isRegex: True
           - not:
               isActivitySender:

--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -41,7 +41,7 @@ configuration:
               # Area-Bots
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[aA]rea[\s-][bB]ots'
+                      pattern: '(?in)\[Policy\]\s+area[\s-]bots'
                       isRegex: True
                 then:
                   - addLabel:
@@ -49,7 +49,7 @@ configuration:
               # Area-Validation-Pipeline
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[aA]rea[\s-][vV]alidation[\s-][pP]ipeline'
+                      pattern: '(?in)\[Policy\]\s+area[\s-]validation[\s-]pipeline'
                       isRegex: True
                 then:
                   - addLabel:
@@ -57,7 +57,7 @@ configuration:
               # Blocking-Issue
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[bB]locking[\s-][iI]ssue'
+                      pattern: '(?in)\[Policy\]\s+blocking[\s-]issue'
                       isRegex: True
                 then:
                   - removeLabel:
@@ -69,7 +69,7 @@ configuration:
               # GitDsc
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Gg]it[Dd][Ss][Cc]'
+                      pattern: '(?in)\[Policy\]\s+GitDSC'
                       isRegex: True
                 then:
                   - addLabel:
@@ -77,7 +77,7 @@ configuration:
               # Help-Wanted
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[hH]elp[\s-][wW]anted'
+                      pattern: '(?in)\[Policy\]\s+help[\s-]wanted'
                       isRegex: True
                 then:
                   - addLabel:
@@ -85,7 +85,7 @@ configuration:
               # In-PR
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Ii]n[\s-][Pp][Rr]'
+                      pattern: '(?in)\[Policy\]\s+In[\s-]PR'
                       isRegex: True
                 then:
                   - addLabel:
@@ -93,7 +93,7 @@ configuration:
               # Issue-Bug
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[iI]ssue[\s-][bB]ug'
+                      pattern: '(?in)\[Policy\]\s+issue[\s-]bug'
                       isRegex: True
                 then:
                   - addLabel:
@@ -101,7 +101,7 @@ configuration:
               # Issue-Docs
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[iI]ssue[\s-][dD]ocs'
+                      pattern: '(?in)\[Policy\]\s+issue[\s-]docs'
                       isRegex: True
                 then:
                   - addLabel:
@@ -109,7 +109,7 @@ configuration:
               # Issue-Feature
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[iI]ssue[\s-][fF]eature'
+                      pattern: '(?in)\[Policy\]\s+issue[\s-]feature'
                       isRegex: True
                 then:
                   - addLabel:
@@ -117,7 +117,7 @@ configuration:
               # Microsoft.DotNet.Dsc
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Mm]icrosoft\.[Dd]ot[Nn]et\.[Dd][Ss][Cc]'
+                      pattern: '(?in)\[Policy\]\s+Microsoft\.DotNet\.DSC'
                       isRegex: True
                 then:
                   - addLabel:
@@ -125,7 +125,7 @@ configuration:
               # Microsoft.VSCode.Dsc
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Mm]icrosoft\.[Vv][Ss][Cc]ode\.[Dd][Ss][Cc]'
+                      pattern: '(?in)\[Policy\]\s+Microsoft\.VSCode\.DSC'
                       isRegex: True
                 then:
                   - addLabel:
@@ -133,7 +133,7 @@ configuration:
               # Microsoft.Windows.Developer
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Mm]icrosoft\.[Ww]indows\.[Dd]eveloper'
+                      pattern: '(?in)\[Policy\]\s+Microsoft\.Windows\.Developer'
                       isRegex: True
                 then:
                   - addLabel:
@@ -141,7 +141,7 @@ configuration:
               # Microsoft.Windows.Setting.Accessibility
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Mm]icrosoft\.[Ww]indows\.[Ss]ettings?\.[Aa]ccessibility'
+                      pattern: '(?in)\[Policy\]\s+Microsoft\.Windows\.Settings?\.Accessibility'
                       isRegex: True
                 then:
                   - addLabel:
@@ -149,7 +149,7 @@ configuration:
               # Microsoft.Windows.Settings
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Mm]icrosoft\.[Ww]indows\.[Ss]ettings'
+                      pattern: '(?in)\[Policy\]\s+Microsoft\.Windows\.Settings'
                       isRegex: True
                 then:
                   - addLabel:
@@ -157,7 +157,7 @@ configuration:
               # Microsoft.Windows.Setting.Language
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Mm]icrosoft\.[Ww]indows\.[Ss]ettings?\.[Ll]anguage'
+                      pattern: '(?in)\[Policy\]\s+Microsoft\.Windows\.Settings?\.Language'
                       isRegex: True
                 then:
                   - addLabel:
@@ -165,7 +165,7 @@ configuration:
               # Microsoft.Windows.Setting.System
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Mm]icrosoft\.[Ww]indows\.[Ss]ettings?\.[Ss]ystem'
+                      pattern: '(?in)\[Policy\]\s+Microsoft\.Windows\.Settings?\.System'
                       isRegex: True
                 then:
                   - addLabel:
@@ -173,7 +173,7 @@ configuration:
               # Microsoft.Windows.Setting
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Mm]icrosoft\.[Ww]indows\.[Ss]ettings?'
+                      pattern: '(?in)\[Policy\]\s+Microsoft\.Windows\.Settings?'
                       isRegex: True
                 then:
                   - addLabel:
@@ -181,7 +181,7 @@ configuration:
               # Moderator-Approved
               # - if:
               #       - commentContains:
-              #             pattern: '\[[Pp]olicy\]\s+[mM]oderator[\s-][Aa]pproved'
+              #             pattern: '(?in)\[Policy\]\s+moderator[\s-]Approved'
               #             isRegex: True
               #   then:
               #       - addLabel:
@@ -189,7 +189,7 @@ configuration:
               # Needs-Attention
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Nn]eeds[\s-][Aa]ttention'
+                      pattern: '(?in)\[Policy\]\s+Needs[\s-]Attention'
                       isRegex: True
                 then:
                   - addLabel:
@@ -206,7 +206,7 @@ configuration:
               # Needs-Author-Feedback
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Nn]eeds[\s-][Aa]uthor[\s-][fF]eedback'
+                      pattern: '(?in)\[Policy\]\s+Needs[\s-]Author[\s-]feedback'
                       isRegex: True
                 then:
                   - addLabel:
@@ -214,7 +214,7 @@ configuration:
               # Needs-CLA
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Nn]eeds[\s-][Cc][Ll][Aa]'
+                      pattern: '(?in)\[Policy\]\s+Needs[\s-]CLA'
                       isRegex: True
                 then:
                   - addLabel:
@@ -222,7 +222,7 @@ configuration:
               # New-DSC-Resource
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Nn]ew[\s-][Dd][Ss][Cc][\s-][Rr]esource'
+                      pattern: '(?in)\[Policy\]\s+New[\s-]DSC[\s-]Resource'
                       isRegex: True
                 then:
                   - addLabel:
@@ -230,7 +230,7 @@ configuration:
               # NpmDsc
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Nn][Pp][Mm]\.[Dd][Ss][Cc]'
+                      pattern: '(?in)\[Policy\]\s+NPM\.DSC'
                       isRegex: True
                 then:
                   - addLabel:
@@ -238,7 +238,7 @@ configuration:
               # PythonPip3Dsc
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Pp]ython[Pp]ip3?[Dd][Ss][Cc]'
+                      pattern: '(?in)\[Policy\]\s+PythonPip3?DSC'
                       isRegex: True
                 then:
                   - addLabel:
@@ -246,7 +246,7 @@ configuration:
               # PSA
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Pp][Ss][Aa]'
+                      pattern: '(?in)\[Policy\]\s+PSA'
                       isRegex: True
                 then:
                   - addLabel:
@@ -254,7 +254,7 @@ configuration:
               # YarnDsc
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[Yy]arn[Dd][Ss][Cc]'
+                      pattern: '(?in)\[Policy\]\s+YarnDSC'
                       isRegex: True
                 then:
                   - addLabel:
@@ -262,7 +262,7 @@ configuration:
               # Unblocked
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[uU]nblocked'
+                      pattern: '(?in)\[Policy\]\s+unblocked'
                       isRegex: True
                 then:
                   - removeLabel:
@@ -270,7 +270,7 @@ configuration:
               # Reset-Feedback
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[rR]eset\s+[fF]eedback'
+                      pattern: '(?in)\[Policy\]\s+reset\s+feedback'
                       isRegex: True
                 then:
                   - removeLabel:
@@ -284,7 +284,7 @@ configuration:
               # Reset-Labels
               - if:
                   - commentContains:
-                      pattern: '\[[Pp]olicy\]\s+[rR]eset[\s-]+[lL]abels'
+                      pattern: '(?in)\[Policy\]\s+reset[\s-]+labels'
                       isRegex: True
                 then:
                   - removeLabel:
@@ -319,6 +319,8 @@ configuration:
                       label: Microsoft.Windows.Setting.Language
                   - removeLabel:
                       label: Microsoft.Windows.Setting.System
+                  - removeLabel:
+                      label: Microsoft.Windows.Settings
                   - removeLabel:
                       label: Microsoft.Windows.Setting
                   #   - removeLabel:
@@ -369,7 +371,7 @@ configuration:
               # Close with reason <>;
               - if:
                   - commentContains:
-                      pattern: "[cC]lose\\s+[wW]ith\\s+[rR]eason\\s*:[\\w\\s\\-\\(\\)\\[\\]\\{\\}\\\\\\/.+=@\\#$%&^*`~|'\",<>?]*(?=;)"
+                      pattern: "(?in)close\\s+with\\s+reason\\s*:[\\w\\s\\-\\(\\)\\[\\]\\{\\}\\\\\\/.+=@\\#$%&^*`~|'\",<>?]*(?=;)"
                       isRegex: True
                 then:
                   - closeIssue
@@ -382,7 +384,7 @@ configuration:
               # Reopen with reason <>;
               - if:
                   - commentContains:
-                      pattern: "[rR]eopen\\s+[wW]ith\\s+[rR]eason\\s*:[\\w\\s\\-\\(\\)\\[\\]\\{\\}\\\\\\/.+=@\\#$%&^*`~|'\",<>?]*(?=;)"
+                      pattern: "(?in)reopen\\s+with\\s+reason\\s*:[\\w\\s\\-\\(\\)\\[\\]\\{\\}\\\\\\/.+=@\\#$%&^*`~|'\",<>?]*(?=;)"
                       isRegex: True
                 then:
                   - reopenIssue

--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -41,7 +41,7 @@ configuration:
               # Area-Bots
               - if:
                   - commentContains:
-                      pattern: '(?in)\[Policy\]\s+area[\s-]bots'
+                      pattern: '(?in)\[Policy\]\s+Area[\s-]Bots'
                       isRegex: True
                 then:
                   - addLabel:
@@ -49,7 +49,7 @@ configuration:
               # Area-Validation-Pipeline
               - if:
                   - commentContains:
-                      pattern: '(?in)\[Policy\]\s+area[\s-]validation[\s-]pipeline'
+                      pattern: '(?in)\[Policy\]\s+Area[\s-]Validation[\s-]Pipeline'
                       isRegex: True
                 then:
                   - addLabel:
@@ -57,7 +57,7 @@ configuration:
               # Blocking-Issue
               - if:
                   - commentContains:
-                      pattern: '(?in)\[Policy\]\s+blocking[\s-]issue'
+                      pattern: '(?in)\[Policy\]\s+Blocking[\s-]Issue'
                       isRegex: True
                 then:
                   - removeLabel:
@@ -69,7 +69,7 @@ configuration:
               # GitDsc
               - if:
                   - commentContains:
-                      pattern: '(?in)\[Policy\]\s+GitDSC'
+                      pattern: '(?in)\[Policy\]\s+GitDsc'
                       isRegex: True
                 then:
                   - addLabel:
@@ -77,7 +77,7 @@ configuration:
               # Help-Wanted
               - if:
                   - commentContains:
-                      pattern: '(?in)\[Policy\]\s+help[\s-]wanted'
+                      pattern: '(?in)\[Policy\]\s+Help[\s-]Wanted'
                       isRegex: True
                 then:
                   - addLabel:
@@ -93,7 +93,7 @@ configuration:
               # Issue-Bug
               - if:
                   - commentContains:
-                      pattern: '(?in)\[Policy\]\s+issue[\s-]bug'
+                      pattern: '(?in)\[Policy\]\s+Issue[\s-]Bug'
                       isRegex: True
                 then:
                   - addLabel:
@@ -101,7 +101,7 @@ configuration:
               # Issue-Docs
               - if:
                   - commentContains:
-                      pattern: '(?in)\[Policy\]\s+issue[\s-]docs'
+                      pattern: '(?in)\[Policy\]\s+Issue[\s-]Docs'
                       isRegex: True
                 then:
                   - addLabel:
@@ -109,7 +109,7 @@ configuration:
               # Issue-Feature
               - if:
                   - commentContains:
-                      pattern: '(?in)\[Policy\]\s+issue[\s-]feature'
+                      pattern: '(?in)\[Policy\]\s+Issue[\s-]Feature'
                       isRegex: True
                 then:
                   - addLabel:
@@ -117,7 +117,7 @@ configuration:
               # Microsoft.DotNet.Dsc
               - if:
                   - commentContains:
-                      pattern: '(?in)\[Policy\]\s+Microsoft\.DotNet\.DSC'
+                      pattern: '(?in)\[Policy\]\s+Microsoft\.DotNet\.Dsc'
                       isRegex: True
                 then:
                   - addLabel:
@@ -125,7 +125,7 @@ configuration:
               # Microsoft.VSCode.Dsc
               - if:
                   - commentContains:
-                      pattern: '(?in)\[Policy\]\s+Microsoft\.VSCode\.DSC'
+                      pattern: '(?in)\[Policy\]\s+Microsoft\.VSCode\.Dsc'
                       isRegex: True
                 then:
                   - addLabel:
@@ -181,7 +181,7 @@ configuration:
               # Moderator-Approved
               # - if:
               #       - commentContains:
-              #             pattern: '(?in)\[Policy\]\s+moderator[\s-]Approved'
+              #             pattern: '(?in)\[Policy\]\s+Moderator[\s-]Approved'
               #             isRegex: True
               #   then:
               #       - addLabel:
@@ -206,7 +206,7 @@ configuration:
               # Needs-Author-Feedback
               - if:
                   - commentContains:
-                      pattern: '(?in)\[Policy\]\s+Needs[\s-]Author[\s-]feedback'
+                      pattern: '(?in)\[Policy\]\s+Needs[\s-]Author[\s-]Feedback'
                       isRegex: True
                 then:
                   - addLabel:
@@ -230,7 +230,7 @@ configuration:
               # NpmDsc
               - if:
                   - commentContains:
-                      pattern: '(?in)\[Policy\]\s+NPM\.DSC'
+                      pattern: '(?in)\[Policy\]\s+Npm\.Dsc'
                       isRegex: True
                 then:
                   - addLabel:
@@ -238,7 +238,7 @@ configuration:
               # PythonPip3Dsc
               - if:
                   - commentContains:
-                      pattern: '(?in)\[Policy\]\s+PythonPip3?DSC'
+                      pattern: '(?in)\[Policy\]\s+PythonPip3?Dsc'
                       isRegex: True
                 then:
                   - addLabel:
@@ -254,7 +254,7 @@ configuration:
               # YarnDsc
               - if:
                   - commentContains:
-                      pattern: '(?in)\[Policy\]\s+YarnDSC'
+                      pattern: '(?in)\[Policy\]\s+YarnDsc'
                       isRegex: True
                 then:
                   - addLabel:
@@ -262,7 +262,7 @@ configuration:
               # Unblocked
               - if:
                   - commentContains:
-                      pattern: '(?in)\[Policy\]\s+unblocked'
+                      pattern: '(?in)\[Policy\]\s+Unblocked'
                       isRegex: True
                 then:
                   - removeLabel:
@@ -270,7 +270,7 @@ configuration:
               # Reset-Feedback
               - if:
                   - commentContains:
-                      pattern: '(?in)\[Policy\]\s+reset\s+feedback'
+                      pattern: '(?in)\[Policy\]\s+Reset\s+Feedback'
                       isRegex: True
                 then:
                   - removeLabel:
@@ -284,7 +284,7 @@ configuration:
               # Reset-Labels
               - if:
                   - commentContains:
-                      pattern: '(?in)\[Policy\]\s+reset[\s-]+labels'
+                      pattern: '(?in)\[Policy\]\s+Reset[\s-]+Labels'
                       isRegex: True
                 then:
                   - removeLabel:
@@ -347,7 +347,7 @@ configuration:
               # Duplicate of #
               - if:
                   - commentContains:
-                      pattern: Duplicate\s+of\s+\#?\s*\d+
+                      pattern: Duplicate\s+Of\s+\#?\s*\d+
                       isRegex: True
                 then:
                   - addReply:
@@ -371,7 +371,7 @@ configuration:
               # Close with reason <>;
               - if:
                   - commentContains:
-                      pattern: "(?in)close\\s+with\\s+reason\\s*:[\\w\\s\\-\\(\\)\\[\\]\\{\\}\\\\\\/.+=@\\#$%&^*`~|'\",<>?]*(?=;)"
+                      pattern: '(?sin)Close\s+with\s+Reason\s*:.+;'
                       isRegex: True
                 then:
                   - closeIssue
@@ -384,7 +384,7 @@ configuration:
               # Reopen with reason <>;
               - if:
                   - commentContains:
-                      pattern: "(?in)reopen\\s+with\\s+reason\\s*:[\\w\\s\\-\\(\\)\\[\\]\\{\\}\\\\\\/.+=@\\#$%&^*`~|'\",<>?]*(?=;)"
+                      pattern: '(?sin)Reopen\s+with\s+Reason\s*:.+;'
                       isRegex: True
                 then:
                   - reopenIssue


### PR DESCRIPTION
## 📖 Description
Fixes Policy Bot rule bugs and modernizes regex patterns by converting the affected expressions to `(?in)` inline flags, aligning label-casing matching, and simplifying the Close/Reopen patterns to match the winget-pkgs approach.

### Changed files
- `.github/actions/spelling/allow.txt`
- `.github/policies/labelManagement.issueOpened.yml`
- `.github/policies/labelManagement.issueUpdated.yml`
- `.github/policies/moderatorTriggers.yml`

Created with GitHub Copilot assistance.

## 🔗 References
Resolves #267

## 🔍 Validation
- Reviewed the updated Policy Bot files and spelling allow list to confirm the regex and pattern consistency changes are present.

## ✅ Checklist
- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
- [ ] Bug fix
- [ ] Feature
- [x] Task
