### PR TITLE
Update v2-to-v3 skill with OptionalFeatureList mapping and operational notes

### DIFF
--- a/samples/Convert to v3/SKILL.md
+++ b/samples/Convert to v3/SKILL.md
@@ -89,6 +89,7 @@ Apply these renames to every resource:
 | `Microsoft.WinGet.DSC/WinGetPackage` | `Microsoft.WinGet/Package` | Renamed |
 | `PSDscResources/Registry` | **`Microsoft.Windows/Registry`** | **Use native v3 resource — dramatically faster** |
 | `PSDscResources/Script` | `Microsoft.DSC.Transitional/RunCommandOnSet` | Or `PowerShellScript`/`WindowsPowerShellScript` if test support needed |
+| `PSDscResources/WindowsOptionalFeature` | `Microsoft.Windows/OptionalFeatureList` | Native v3, batch multiple features in one resource |
 | `Microsoft.Windows.Developer/*` | `Microsoft.Windows.Developer/*` | Unchanged (adapted resource, requires module install) |
 | `Microsoft.Windows.Settings/*` | `Microsoft.Windows.Settings/*` | Unchanged (adapted resource, requires module install) |
 
@@ -417,6 +418,48 @@ Fixed overhead for dscv3 processor startup is approximately 23 seconds.
 > is the single highest-impact optimization when converting a v2 config to v3. A config with
 > 22 registry keys drops from 30+ minutes to under 2 minutes for registry evaluation alone.
 > This also eliminates the need to install the PSDscResources PowerShell module.
+
+## Windows Optional Features (`Microsoft.Windows/OptionalFeatureList`)
+
+A native v3 resource (no adapter needed) for enabling/disabling Windows Optional Features.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `features` | array | List of feature objects |
+| `features[].featureName` | string | Windows feature name |
+| `features[].state` | enum | `Installed`, `NotPresent`, `Removed` |
+
+**Common feature names** (not intuitive — use these exact strings):
+- `Containers-DisposableClientVM` → Windows Sandbox
+- `Microsoft-Hyper-V-All` → Hyper-V (all components)
+- `VirtualMachinePlatform` → Virtual Machine Platform
+- `Microsoft-Windows-Subsystem-Linux` → WSL
+
+```yaml
+- type: Microsoft.Windows/OptionalFeatureList
+  name: WindowsFeatures
+  properties:
+    features:
+    - featureName: Containers-DisposableClientVM
+      state: Installed
+    - featureName: Microsoft-Hyper-V-All
+      state: Installed
+  metadata:
+    winget:
+      securityContext: elevated
+    description: Enable Windows Sandbox and Hyper-V
+```
+
+**v2 equivalent** uses `PSDscResources/WindowsOptionalFeature` (one resource per feature).
+
+## Operational Notes for Testing and Automation
+
+- **v2 module caching:** WinGet v2 caches modules at `%LOCALAPPDATA%\Microsoft\WinGet\Configuration\Modules\` — separate from `$env:PSModulePath`. Modules here can become stale.
+- **v3 uses standard PS paths:** The dscv3 processor uses `$env:PSModulePath`. Modules must be installed explicitly via `Install-PSResource` in a `RunCommandOnSet` resource before use.
+- **Concurrent operations blocked:** Never run two `winget configure` commands simultaneously — WinGet prevents parallel runs.
+- **`--disable-interactivity`** does not suppress the progress spinner. Stdout is flooded with ANSI sequences.
+- **Adapter resources work in v3:** dscv3 processor handles PowerShell adapter resources (GitDsc, StorageDsc, etc.) when modules are in the standard PS path.
+- **PowerToys:** v2 DSC resources are deprecated. Use native v3 `Microsoft.PowerToys/*` resources.
 
 ## Conversion Checklist
 


### PR DESCRIPTION
## 📖 Description

Updates the v2-to-v3 conversion skill with new learnings from building curated WinGet Configuration files:

- **New resource type mapping:** `PSDscResources/WindowsOptionalFeature` → `Microsoft.Windows/OptionalFeatureList` (native v3, batch multiple features)
- **Full `OptionalFeatureList` reference section** with property table, common feature names (`Containers-DisposableClientVM` for Sandbox, `Microsoft-Hyper-V-All` for Hyper-V), and complete YAML example
- **Operational Notes section** documenting v2 vs v3 module path differences, concurrent operation limitations, spinner behavior, and adapter resource confirmation
- **PowerToys v2 deprecation note** directing users to native v3 `Microsoft.PowerToys/*` resources

Created with GitHub Copilot assistance.

## 🔍 References

Learnings gathered while building and testing configurations at [denelon/setup#4](https://github.com/denelon/setup/pull/4).

## 🔎 Validation

- Skill YAML examples validated
- All resource mappings verified against actual `winget configure test` runs on both v2 and v3 configs
- OptionalFeatureList properties confirmed against `dsc resource schema Microsoft.Windows/OptionalFeatureList`

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type

- [ ] Bug fix
- [x] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-dsc/pull/286)