### PR TITLE
Fix skill link in samples README to point to SKILL.md

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -28,7 +28,7 @@ Examples for a few specific DSC Resources are under the [DscResources](./DscReso
 
 ### Converting v2 to v3
 
-If you have existing v2 configuration files and want to convert them to the dscv3 processor syntax, see the [Convert to v3](./Convert%20to%20v3/) guide. It includes a step-by-step conversion reference, a checklist, and a [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-in-the-cli) skill that automates the conversion process.
+If you have existing v2 configuration files and want to convert them to the dscv3 processor syntax, see the [Convert to v3](./Convert%20to%20v3/) guide. It includes a step-by-step conversion reference, a checklist, and a GitHub Copilot CLI [skill](./Convert%20to%20v3/SKILL.md) that automates the conversion process.
 
 ### Create your own
 


### PR DESCRIPTION
## 📖 Description

Fixes the skill link in `samples/README.md`. The "Converting v2 to v3" section previously linked "GitHub Copilot CLI" to the external Copilot CLI docs page. The intent was to link the word "skill" to the actual `SKILL.md` file in the `Convert to v3` directory.

Created with GitHub Copilot assistance.

## 🔗 References

Resolves https://github.com/microsoft/winget-dsc/issues/289

## 🔍 Validation

- Verified the relative link `./Convert%20to%20v3/SKILL.md` resolves correctly in the repo structure.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-dsc/pull/290)