### PR TITLE
 Change ExtraArgs/Arguments to string[] in GitDsc, NpmDsc, and PythonPip3Dsc

### DIFF
--- a/resources/GitDsc/GitDsc.psd1
+++ b/resources/GitDsc/GitDsc.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'GitDsc.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.1.0'
+    ModuleVersion        = '0.2.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/resources/GitDsc/GitDsc.psm1
+++ b/resources/GitDsc/GitDsc.psm1
@@ -103,7 +103,7 @@ class GitClone {
         if (Test-Path $expectedDirectory) {
             Set-Location -Path $expectedDirectory
             try {
-                $gitRemoteValue = Invoke-GitRemote("get-url $($currentState.RemoteName)")
+                $gitRemoteValue = Invoke-GitRemote -Arguments @('get-url', $currentState.RemoteName)
                 if ($this.HttpsUrl.StartsWith($gitRemoteValue)) {
                     $currentState.Ensure = [Ensure]::Present
                 }
@@ -131,17 +131,18 @@ class GitClone {
 
         Set-Location $this.RootDirectory
 
-        if ($this.FolderName) {
-            $cloneArgs = "$($this.HttpsUrl) $($this.FolderName)"
-        } else {
-            $cloneArgs = $this.HttpsUrl
-        }
-
+        $cloneArgs = [List[string]]::new()
         if ($this.ExtraArgs) {
-            $cloneArgs = "$($this.ExtraArgs) $cloneArgs"
+            foreach ($a in ($this.ExtraArgs -split '\s+' | Where-Object { $_ })) {
+                $cloneArgs.Add($a)
+            }
+        }
+        $cloneArgs.Add($this.HttpsUrl)
+        if ($this.FolderName) {
+            $cloneArgs.Add($this.FolderName)
         }
 
-        Invoke-GitClone($cloneArgs)
+        Invoke-GitClone -Arguments $cloneArgs
     }
 }
 
@@ -206,7 +207,7 @@ class GitRemote {
 
         Set-Location $this.ProjectDirectory
         try {
-            $gitRemoteValue = Invoke-GitRemote("get-url $($this.RemoteName)")
+            $gitRemoteValue = Invoke-GitRemote -Arguments @('get-url', $this.RemoteName)
             $currentState.Ensure = ($gitRemoteValue -like $this.RemoteUrl) ? [Ensure]::Present : [Ensure]::Absent
         } catch {
             $currentState.Ensure = [Ensure]::Absent
@@ -225,13 +226,13 @@ class GitRemote {
 
         if ($this.Ensure -eq [Ensure]::Present) {
             try {
-                Invoke-GitRemote("add $($this.RemoteName) $($this.RemoteUrl)")
+                Invoke-GitRemote -Arguments @('add', $this.RemoteName, $this.RemoteUrl)
             } catch {
                 throw 'Failed to add remote repository.'
             }
         } else {
             try {
-                Invoke-GitRemote("remove $($this.RemoteName)")
+                Invoke-GitRemote -Arguments @('remove', $this.RemoteName)
             } catch {
                 throw 'Failed to remove remote repository.'
             }
@@ -305,8 +306,8 @@ class GitConfigUserName {
             }
         }
 
-        $configArgs = ConstructGitConfigUserArguments -Arguments 'user.name' -ConfigLocation $this.ConfigLocation
-        $result = Invoke-GitConfig($configArgs)
+        $configArgs = ConstructGitConfigUserArguments -Arguments @('user.name') -ConfigLocation $this.ConfigLocation
+        $result = Invoke-GitConfig -Arguments $configArgs
         $currentState.Ensure = ($currentState.UserName -eq $result) ? [Ensure]::Present : [Ensure]::Absent
         return $currentState
     }
@@ -326,12 +327,12 @@ class GitConfigUserName {
         }
 
         if ($this.Ensure -eq [Ensure]::Present) {
-            $configArgs = ConstructGitConfigUserArguments -Arguments "user.name '$($this.UserName)'" -ConfigLocation $this.ConfigLocation
+            $configArgs = ConstructGitConfigUserArguments -Arguments @('user.name', $this.UserName) -ConfigLocation $this.ConfigLocation
         } else {
-            $configArgs = ConstructGitConfigUserArguments -Arguments '--unset user.name' -ConfigLocation $this.ConfigLocation
+            $configArgs = ConstructGitConfigUserArguments -Arguments @('--unset', 'user.name') -ConfigLocation $this.ConfigLocation
         }
 
-        Invoke-GitConfig($configArgs)
+        Invoke-GitConfig -Arguments $configArgs
     }
 }
 
@@ -401,8 +402,8 @@ class GitConfigUserEmail {
             }
         }
 
-        $configArgs = ConstructGitConfigUserArguments -Arguments 'user.email' -ConfigLocation $this.ConfigLocation
-        $result = Invoke-GitConfig($configArgs)
+        $configArgs = ConstructGitConfigUserArguments -Arguments @('user.email') -ConfigLocation $this.ConfigLocation
+        $result = Invoke-GitConfig -Arguments $configArgs
         $currentState.Ensure = ($currentState.UserEmail -eq $result) ? [Ensure]::Present : [Ensure]::Absent
         return $currentState
     }
@@ -422,12 +423,12 @@ class GitConfigUserEmail {
         }
 
         if ($this.Ensure -eq [Ensure]::Present) {
-            $configArgs = ConstructGitConfigUserArguments -Arguments "user.email $($this.UserEmail)" -ConfigLocation $this.ConfigLocation
+            $configArgs = ConstructGitConfigUserArguments -Arguments @('user.email', $this.UserEmail) -ConfigLocation $this.ConfigLocation
         } else {
-            $configArgs = ConstructGitConfigUserArguments -Arguments '--unset user.email' -ConfigLocation $this.ConfigLocation
+            $configArgs = ConstructGitConfigUserArguments -Arguments @('--unset', 'user.email') -ConfigLocation $this.ConfigLocation
         }
 
-        Invoke-GitConfig($configArgs)
+        Invoke-GitConfig -Arguments $configArgs
     }
 }
 
@@ -458,63 +459,53 @@ function GetGitProjectName {
 function Invoke-GitConfig {
     param(
         [Parameter()]
-        [string]$Arguments
+        [string[]]$Arguments = @()
     )
 
-    $command = [List[string]]::new()
-    $command.Add('config')
-    $command.Add($Arguments)
-    return Invoke-Git -Command $command
+    return Invoke-Git -Command (@('config') + $Arguments)
 }
 
 function Invoke-GitRemote {
     param(
         [Parameter()]
-        [string]$Arguments
+        [string[]]$Arguments = @()
     )
 
-    $command = [List[string]]::new()
-    $command.Add('remote')
-    $command.Add($Arguments)
-    return Invoke-Git -Command $command
+    return Invoke-Git -Command (@('remote') + $Arguments)
 }
 
 function Invoke-GitClone {
     param(
         [Parameter()]
-        [string]$Arguments
+        [string[]]$Arguments = @()
     )
 
-    $command = [List[string]]::new()
-    $command.Add('clone')
-    $command.Add($Arguments)
-    return Invoke-Git -Command $command
+    return Invoke-Git -Command (@('clone') + $Arguments)
 }
 
 function Invoke-Git {
     param (
         [Parameter(Mandatory = $true)]
-        [string]$Command
+        [string[]]$Command
     )
 
-    return Invoke-Expression -Command "git $Command"
+    $argList = @($Command | Where-Object { -not [string]::IsNullOrEmpty($_) })
+    return & git @argList
 }
 
 function ConstructGitConfigUserArguments {
     param(
         [Parameter(Mandatory)]
-        [string]$Arguments,
+        [string[]]$Arguments,
 
         [Parameter(Mandatory)]
         [ConfigLocation]$ConfigLocation
     )
 
-    $ConfigArguments = $Arguments
-    if ([ConfigLocation]::None -ne $this.ConfigLocation) {
-        $ConfigArguments = "--$($this.ConfigLocation) $($ConfigArguments)"
+    if ([ConfigLocation]::None -ne $ConfigLocation) {
+        return @("--$ConfigLocation") + $Arguments
     }
-
-    return $ConfigArguments
+    return $Arguments
 }
 
 function Assert-IsAdministrator {
@@ -534,7 +525,7 @@ function Assert-GitUrl {
         [string]$HttpsUrl
     )
 
-    $out = Invoke-Git -Command "ls-remote $HttpsUrl *" 2>&1
+    $out = Invoke-Git -Command @('ls-remote', $HttpsUrl, '*') 2>&1
 
     if ($LASTEXITCODE -ne 0) {
         throw "Invalid Git URL: $HttpsUrl. Error: $out"

--- a/resources/GitDsc/GitDsc.psm1
+++ b/resources/GitDsc/GitDsc.psm1
@@ -47,7 +47,8 @@ enum ConfigLocation {
         The folder name for the cloned repository. If not specified, it is derived from the HTTPS URL.
 
     .PARAMETER ExtraArgs
-        Additional arguments to pass to `git clone`.
+        Additional arguments to pass to `git clone`, provided as an array of strings where each
+        element is a separate argument.
 
     .EXAMPLE
         Invoke-DscResource -ModuleName GitDsc -Name GitClone -Method Set -Property @{
@@ -56,6 +57,15 @@ enum ConfigLocation {
         }
 
         This example clones the winget-dsc repository into C:\repos.
+
+    .EXAMPLE
+        Invoke-DscResource -ModuleName GitDsc -Name GitClone -Method Set -Property @{
+            HttpsUrl      = 'https://github.com/microsoft/winget-dsc'
+            RootDirectory = 'C:\repos'
+            ExtraArgs     = @('--depth', '1')
+        }
+
+        This example performs a shallow clone of the winget-dsc repository into C:\repos.
 #>
 [DSCResource()]
 class GitClone {
@@ -77,7 +87,7 @@ class GitClone {
     [string]$FolderName
 
     [DscProperty()]
-    [string]$ExtraArgs
+    [string[]]$ExtraArgs
 
     [GitClone] Get() {
         Assert-Git
@@ -133,7 +143,7 @@ class GitClone {
 
         $cloneArgs = [List[string]]::new()
         if ($this.ExtraArgs) {
-            foreach ($a in ($this.ExtraArgs -split '\s+' | Where-Object { $_ })) {
+            foreach ($a in ($this.ExtraArgs | Where-Object { $_ })) {
                 $cloneArgs.Add($a)
             }
         }

--- a/resources/GitDsc/gitdsc.dsc.manifests.json
+++ b/resources/GitDsc/gitdsc.dsc.manifests.json
@@ -4,7 +4,7 @@
       "requireAdapter": "Microsoft.Adapter/PowerShell",
       "$schema": "https://aka.ms/dsc/schemas/v3/bundled/adaptedresource/manifest.json",
       "kind": "resource",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "type": "GitDsc/GitClone",
       "author": "DscSamples",
       "description": "The `GitClone` DSC resource is used to clone a Git repository to a local directory.",
@@ -43,9 +43,12 @@
               "description": "The folder name for the cloned repository. If not specified, it is derived from the HTTPS URL."
             },
             "ExtraArgs": {
-              "type": "string",
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
               "title": "ExtraArgs",
-              "description": "Additional arguments to pass to `git clone`."
+              "description": "Additional arguments to pass to `git clone`, provided as an array of strings where each element is a separate argument."
             }
           },
           "description": "The `GitClone` DSC resource is used to clone a Git repository to a local directory.",
@@ -58,7 +61,7 @@
       "requireAdapter": "Microsoft.Adapter/PowerShell",
       "$schema": "https://aka.ms/dsc/schemas/v3/bundled/adaptedresource/manifest.json",
       "kind": "resource",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "type": "GitDsc/GitRemote",
       "author": "DscSamples",
       "description": "The `GitRemote` DSC resource is used to manage remote repository references in a Git project.",
@@ -102,7 +105,7 @@
       "requireAdapter": "Microsoft.Adapter/PowerShell",
       "$schema": "https://aka.ms/dsc/schemas/v3/bundled/adaptedresource/manifest.json",
       "kind": "resource",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "type": "GitDsc/GitConfigUserName",
       "author": "DscSamples",
       "description": "The `GitConfigUserName` DSC resource is used to manage the Git user name configuration.",
@@ -147,7 +150,7 @@
       "requireAdapter": "Microsoft.Adapter/PowerShell",
       "$schema": "https://aka.ms/dsc/schemas/v3/bundled/adaptedresource/manifest.json",
       "kind": "resource",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "type": "GitDsc/GitConfigUserEmail",
       "author": "DscSamples",
       "description": "The `GitConfigUserEmail` DSC resource is used to manage the Git user email configuration.",

--- a/resources/NpmDsc/NpmDsc.psd1
+++ b/resources/NpmDsc/NpmDsc.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'NpmDsc.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.1.0'
+    ModuleVersion        = '0.2.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/resources/NpmDsc/NpmDsc.psm1
+++ b/resources/NpmDsc/NpmDsc.psm1
@@ -15,13 +15,15 @@ function Assert-Npm {
 function Invoke-Npm {
     param (
         [Parameter(Mandatory = $true)]
-        [string]$Command
+        [string[]]$Command
     )
-    $value = Invoke-Expression -Command "npm $Command"
+
+    $argList = @($Command | Where-Object { -not [string]::IsNullOrEmpty($_) })
+    $value = & npm @argList
 
     if ($LASTEXITCODE -ne 0) {
         $errors = Get-NpmErrorMessages -LogPath (GetNpmPath)
-        throw "Command 'npm $($Command.Trim())' failed: $($errors -join '; ')"
+        throw "Command 'npm $($argList -join ' ')' failed: $($errors -join '; ')"
     }
 
     return $value
@@ -71,15 +73,19 @@ function Install-NpmPackage {
 
     $command = [List[string]]::new()
     $command.Add('install')
-    $command.Add($PackageName)
+    if (-not [string]::IsNullOrEmpty($PackageName)) {
+        $command.Add($PackageName)
+    }
 
     if ($Global) {
         $command.Add('-g')
     }
 
-    $command.Add($Arguments)
+    foreach ($a in ($Arguments -split '\s+' | Where-Object { $_ })) {
+        $command.Add($a)
+    }
 
-    Write-Verbose -Message "Executing 'npm $command'"
+    Write-Verbose -Message "Executing 'npm $($command -join ' ')'"
 
     return Invoke-Npm -Command $command
 }
@@ -104,9 +110,11 @@ function Uninstall-NpmPackage {
         $command.Add('-g')
     }
 
-    $command.Add($Arguments)
+    foreach ($a in ($Arguments -split '\s+' | Where-Object { $_ })) {
+        $command.Add($a)
+    }
 
-    Write-Verbose -Message "Executing 'npm $command'"
+    Write-Verbose -Message "Executing 'npm $($command -join ' ')'"
 
     return Invoke-Npm -Command $command
 }
@@ -120,7 +128,7 @@ function GetNpmPath {
         } elseif (Test-Path $globalNpmCacheDir -ErrorAction SilentlyContinue) {
             return $globalNpmCacheDir
         } else {
-            $result = (Invoke-Npm -Command 'config list --json' | ConvertFrom-Json -ErrorAction SilentlyContinue).cache
+            $result = (Invoke-Npm -Command @('config', 'list', '--json') | ConvertFrom-Json -ErrorAction SilentlyContinue).cache
             if (Test-Path $result -ErrorAction SilentlyContinue) {
                 return $result
             } else {
@@ -399,7 +407,7 @@ class NpmPackage {
     static [NpmPackage[]] Export() {
         $packages = Get-InstalledNpmPackages -Global $true | ConvertFrom-Json -AsHashtable | Select-Object -ExpandProperty dependencies
         $out = [List[NpmPackage]]::new()
-        $globalDir = (Join-Path -Path (Invoke-Npm -Command 'config get prefix') -ChildPath 'node_modules')
+        $globalDir = (Join-Path -Path (Invoke-Npm -Command @('config', 'get', 'prefix')) -ChildPath 'node_modules')
         foreach ($package in $packages.GetEnumerator()) {
             $in = [NpmPackage]@{
                 Name             = $package.Name

--- a/resources/NpmDsc/NpmDsc.psm1
+++ b/resources/NpmDsc/NpmDsc.psm1
@@ -68,7 +68,7 @@ function Install-NpmPackage {
         [bool]$Global,
 
         [Parameter()]
-        [string]$Arguments
+        [string[]]$Arguments
     )
 
     $command = [List[string]]::new()
@@ -81,7 +81,7 @@ function Install-NpmPackage {
         $command.Add('-g')
     }
 
-    foreach ($a in ($Arguments -split '\s+' | Where-Object { $_ })) {
+    foreach ($a in ($Arguments | Where-Object { $_ })) {
         $command.Add($a)
     }
 
@@ -99,7 +99,7 @@ function Uninstall-NpmPackage {
         [bool]$Global,
 
         [Parameter()]
-        [string]$Arguments
+        [string[]]$Arguments
     )
 
     $command = [List[string]]::new()
@@ -110,7 +110,7 @@ function Uninstall-NpmPackage {
         $command.Add('-g')
     }
 
-    foreach ($a in ($Arguments -split '\s+' | Where-Object { $_ })) {
+    foreach ($a in ($Arguments | Where-Object { $_ })) {
         $command.Add($a)
     }
 
@@ -224,7 +224,8 @@ enum Ensure {
         The directory containing the `package.json` file. If not specified, the current directory is used.
 
     .PARAMETER Arguments
-        Additional arguments to pass to `npm install`.
+        Additional arguments to pass to `npm install`, provided as an array of strings where each
+        element is a separate argument.
 
     .EXAMPLE
         Invoke-DscResource -ModuleName NpmDsc -Name NpmInstall -Method Set -Property @{
@@ -248,7 +249,7 @@ class NpmInstall {
     [string]$PackageDirectory
 
     [DscProperty()]
-    [string]$Arguments
+    [string[]]$Arguments
 
     [NpmInstall] Get() {
         Assert-Npm
@@ -316,7 +317,8 @@ class NpmInstall {
     Indicates whether the npm package should be installed globally.
 
 .PARAMETER Arguments
-    Additional arguments to pass to `npm install` or `npm uninstall`.
+    Additional arguments to pass to `npm install` or `npm uninstall`, provided as an array of strings
+    where each element is a separate argument.
 
 .EXAMPLE
     PS C:\> Invoke-DscResource -ModuleName NpmDsc -Name NpmPackage -Method Set -Property @{ Name = 'react' }
@@ -351,7 +353,7 @@ class NpmPackage {
     [bool]$Global
 
     [DscProperty()]
-    [string]$Arguments
+    [string[]]$Arguments
 
     [NpmPackage] Get() {
         Assert-Npm
@@ -426,7 +428,7 @@ class NpmPackage {
 
     [string] WhatIf() {
         if ($this.Ensure -eq [Ensure]::Present) {
-            $whatIfState = Install-NpmPackage -PackageName $this.Name -Global $this.Global -Arguments '--dry-run'
+            $whatIfState = Install-NpmPackage -PackageName $this.Name -Global $this.Global -Arguments @('--dry-run')
 
             $out = @{
                 Name      = $this.Name

--- a/resources/NpmDsc/npmdsc.dsc.manifests.json
+++ b/resources/NpmDsc/npmdsc.dsc.manifests.json
@@ -4,7 +4,7 @@
       "requireAdapter": "Microsoft.Adapter/PowerShell",
       "$schema": "https://aka.ms/dsc/schemas/v3/bundled/adaptedresource/manifest.json",
       "kind": "resource",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "type": "NpmDsc/NpmInstall",
       "author": "DscSamples",
       "description": "The `NpmInstall` DSC resource is used to install all npm packages listed in a `package.json` file.",
@@ -38,9 +38,12 @@
               "description": "The directory containing the `package.json` file. If not specified, the current directory is used."
             },
             "Arguments": {
-              "type": "string",
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
               "title": "Arguments",
-              "description": "Additional arguments to pass to `npm install`."
+              "description": "Additional arguments to pass to `npm install`, provided as an array of strings where each element is a separate argument."
             }
           },
           "description": "The `NpmInstall` DSC resource is used to install all npm packages listed in a `package.json` file.",
@@ -53,7 +56,7 @@
       "requireAdapter": "Microsoft.Adapter/PowerShell",
       "$schema": "https://aka.ms/dsc/schemas/v3/bundled/adaptedresource/manifest.json",
       "kind": "resource",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "type": "NpmDsc/NpmPackage",
       "author": "DscSamples",
       "description": "The `NpmPackage` DSC Resource allows you to manage the installation, update, and removal of npm packages. This resource ensures that the specified npm package is in the desired state.",
@@ -92,9 +95,12 @@
               "description": "Indicates whether the npm package should be installed globally."
             },
             "Arguments": {
-              "type": "string",
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
               "title": "Arguments",
-              "description": "Additional arguments to pass to `npm install` or `npm uninstall`."
+              "description": "Additional arguments to pass to `npm install` or `npm uninstall`, provided as an array of strings where each element is a separate argument."
             }
           },
           "description": "The `NpmPackage` DSC Resource allows you to manage the installation, update, and removal of npm packages. This resource ensures that the specified npm package is in the desired state.",

--- a/resources/PythonPip3Dsc/PythonPip3Dsc.psd1
+++ b/resources/PythonPip3Dsc/PythonPip3Dsc.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'PythonPip3Dsc.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.1.0'
+    ModuleVersion        = '0.2.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/resources/PythonPip3Dsc/PythonPip3Dsc.psm1
+++ b/resources/PythonPip3Dsc/PythonPip3Dsc.psm1
@@ -13,8 +13,7 @@ function Invoke-Process {
         [string]$FilePath,
 
         [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [string]$ArgumentList
+        [string[]]$ArgumentList
     )
 
     try {
@@ -25,7 +24,9 @@ function Invoke-Process {
         $pinfo.UseShellExecute = $false
         $pinfo.WindowStyle = 'Hidden'
         $pinfo.CreateNoWindow = $true
-        $pinfo.Arguments = $ArgumentList
+        foreach ($arg in @($ArgumentList | Where-Object { $null -ne $_ })) {
+            [void]$pinfo.ArgumentList.Add([string]$arg)
+        }
         $p = New-Object System.Diagnostics.Process
         $p.StartInfo = $pinfo
         $p.Start() | Out-Null
@@ -54,7 +55,7 @@ function Invoke-Process {
 
         return $result
     } catch {
-        Write-Verbose -Message "Error occurred while executing the command: $FilePath $ArgumentList. Error:"
+        Write-Verbose -Message "Error occurred while executing the command: $FilePath $($ArgumentList -join ' '). Error:"
         Write-Verbose -Message $stErr
     }
 }
@@ -114,7 +115,7 @@ function Assert-Pip3 {
     # Try invoking pip3 help with the alias. If it fails, switch to calling npm.cmd directly.
     # This may occur if npm is installed in the same shell window and the alias is not updated until the shell window is restarted.
     try {
-        Invoke-Pip3 -command 'help'
+        Invoke-Pip3 -command @('help')
         return
     } catch {}
 
@@ -171,8 +172,10 @@ function Invoke-Pip3Install {
         $command.Add('--dry-run')
     }
 
-    $command.Add($Arguments)
-    Write-Verbose -Message "Executing 'pip' install with command: $command"
+    foreach ($a in ($Arguments -split '\s+' | Where-Object { $_ })) {
+        $command.Add($a)
+    }
+    Write-Verbose -Message "Executing 'pip' install with command: $($command -join ' ')"
     $result = Invoke-Pip3 -command $command
 
     return $result
@@ -193,7 +196,9 @@ function Invoke-Pip3Uninstall {
     $command = [List[string]]::new()
     $command.Add('uninstall')
     $command.Add((Get-PackageNameWithVersion -PackageName $PackageName -Version $Version))
-    $command.Add($Arguments)
+    foreach ($a in ($Arguments -split '\s+' | Where-Object { $_ })) {
+        $command.Add($a)
+    }
 
     # '--yes' is needed to ignore conformation required for uninstalls
     $command.Add('--yes')
@@ -242,17 +247,15 @@ function GetPip3CurrentState {
 }
 
 function GetInstalledPip3Packages {
-    $Arguments = [List[string]]::new()
-    $Arguments.Add('list')
-    $Arguments.Add('--format=json')
+    $arguments = @('list', '--format=json')
 
     if ($global:usePip3Exe) {
-        $command = "& '$global:pip3ExePath' " + $Arguments
+        $proc = Invoke-Process -FilePath $global:pip3ExePath -ArgumentList $arguments
     } else {
-        $command = '& pip3 ' + $Arguments
+        $proc = Invoke-Process -FilePath 'pip3' -ArgumentList $arguments
     }
 
-    $res = Invoke-Expression -Command $command | ConvertFrom-Json
+    $res = ($proc.StdOut -join "`n") | ConvertFrom-Json
 
     $result = $res | ForEach-Object {
         @{
@@ -267,7 +270,7 @@ function GetInstalledPip3Packages {
 function Invoke-Pip3 {
     param (
         [Parameter(Mandatory)]
-        [string]$command
+        [string[]]$command
     )
 
     if ($global:usePip3Exe) {

--- a/resources/PythonPip3Dsc/PythonPip3Dsc.psm1
+++ b/resources/PythonPip3Dsc/PythonPip3Dsc.psm1
@@ -150,7 +150,7 @@ function Invoke-Pip3Install {
         [string]$PackageName,
 
         [Parameter()]
-        [string]$Arguments,
+        [string[]]$Arguments,
 
         [Parameter()]
         [string]$Version,
@@ -172,7 +172,7 @@ function Invoke-Pip3Install {
         $command.Add('--dry-run')
     }
 
-    foreach ($a in ($Arguments -split '\s+' | Where-Object { $_ })) {
+    foreach ($a in ($Arguments | Where-Object { $_ })) {
         $command.Add($a)
     }
     Write-Verbose -Message "Executing 'pip' install with command: $($command -join ' ')"
@@ -187,7 +187,7 @@ function Invoke-Pip3Uninstall {
         [string]$PackageName,
 
         [Parameter()]
-        [string]$Arguments,
+        [string[]]$Arguments,
 
         [Parameter()]
         [string]$Version
@@ -196,7 +196,7 @@ function Invoke-Pip3Uninstall {
     $command = [List[string]]::new()
     $command.Add('uninstall')
     $command.Add((Get-PackageNameWithVersion -PackageName $PackageName -Version $Version))
-    foreach ($a in ($Arguments -split '\s+' | Where-Object { $_ })) {
+    foreach ($a in ($Arguments | Where-Object { $_ })) {
         $command.Add($a)
     }
 
@@ -249,11 +249,8 @@ function GetPip3CurrentState {
 function GetInstalledPip3Packages {
     $arguments = @('list', '--format=json')
 
-    if ($global:usePip3Exe) {
-        $proc = Invoke-Process -FilePath $global:pip3ExePath -ArgumentList $arguments
-    } else {
-        $proc = Invoke-Process -FilePath 'pip3' -ArgumentList $arguments
-    }
+    $pip3ExePath = $global:usePip3Exe ? $global:pip3ExePath : 'pip3'
+    $proc = Invoke-Process -FilePath $pip3ExePath -ArgumentList $arguments
 
     $res = ($proc.StdOut -join "`n") | ConvertFrom-Json
 
@@ -331,7 +328,8 @@ Assert-Pip3
     The version of the Python package to manage. If not specified, the latest version will be used.
 
 .PARAMETER Arguments
-    Additional arguments to pass to pip3.
+    Additional arguments to pass to pip3, provided as an array of strings where each element is a
+    separate argument.
 
 .PARAMETER InstalledPackages
     A list of installed packages. This property is not configurable.
@@ -360,7 +358,7 @@ class Pip3Package {
     [string]$Version
 
     [DscProperty()]
-    [string]$Arguments
+    [string[]]$Arguments
 
     [DscProperty()]
     [bool] $Exist = $true

--- a/resources/PythonPip3Dsc/pythonpip3dsc.dsc.manifests.json
+++ b/resources/PythonPip3Dsc/pythonpip3dsc.dsc.manifests.json
@@ -4,7 +4,7 @@
       "requireAdapter": "Microsoft.Adapter/PowerShell",
       "$schema": "https://aka.ms/dsc/schemas/v3/bundled/adaptedresource/manifest.json",
       "kind": "resource",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "type": "PythonPip3Dsc/Pip3Package",
       "author": "DscSamples",
       "description": "The `Pip3Package` DSC Resource allows you to install, update, and uninstall Python packages using pip3.",
@@ -27,9 +27,12 @@
               "description": "The version of the Python package to manage. If not specified, the latest version will be used."
             },
             "Arguments": {
-              "type": "string",
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
               "title": "Arguments",
-              "description": "Additional arguments to pass to pip3."
+              "description": "Additional arguments to pass to pip3, provided as an array of strings where each element is a separate argument."
             },
             "Exist": {
               "type": "boolean",

--- a/tests/GitDsc/GitDsc.tests.ps1
+++ b/tests/GitDsc/GitDsc.tests.ps1
@@ -61,7 +61,7 @@ Describe 'GitDsc' {
         $desiredState = @{
             HttpsUrl      = 'https://github.com/microsoft/winget-dsc.git'
             RootDirectory = $env:TEMP
-            ExtraArgs     = '--filter=blob:none --no-checkout'
+            ExtraArgs     = @('--filter=blob:none', '--no-checkout')
         }
 
         Invoke-DscResource -Name GitClone -ModuleName GitDsc -Method Set -Property $desiredState

--- a/tests/NpmDsc/NpmDsc.tests.ps1
+++ b/tests/NpmDsc/NpmDsc.tests.ps1
@@ -107,7 +107,7 @@ Describe 'NpmPackage' {
         $whatIf = $npmPackage.WhatIf() | ConvertFrom-Json
 
         # Don't want to rely on version in parameters so we call npm view to get the remote version
-        $latestVersion = Invoke-Npm -Command "view $($whatIfState.Name) version"
+        $latestVersion = Invoke-Npm -Command @('view', $whatIfState.Name, 'version')
 
         $whatIf.Name | Should -Be 'react'
         $whatIf._metaData.whatIf | Should -Contain "add react $latestVersion"


### PR DESCRIPTION
## 📖 Description
Internal helpers in GitDsc, NpmDsc, and PythonPip3Dsc previously concatenated DSC property values into a single string and executed it via Invoke-Expression (or, in PythonPip3Dsc, joined with spaces into ProcessStartInfo.Arguments). This PR refactors those helpers to build a [string[]] argument list and invoke the underlying CLI via `& git @args` / `& npm @args` / `ProcessStartInfo.ArgumentList.Add(...)`, so each value is passed as a distinct argv entry with no re-parsing.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-dsc/pull/291)