### PR TITLE
Fix test failures in Npm and VSCode

### DIFF
--- a/resources/Microsoft.VSCode.Dsc/Microsoft.VSCode.Dsc.psm1
+++ b/resources/Microsoft.VSCode.Dsc/Microsoft.VSCode.Dsc.psm1
@@ -146,7 +146,6 @@ function Invoke-VSCode {
 
     $stdErrTempFile = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath (New-Guid).Guid
     $stdOutTempFile = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath (New-Guid).Guid
-    $invocationSuccess = $true
 
     $processParams = @{
         FilePath               = $VSCodeCLIPath
@@ -160,14 +159,14 @@ function Invoke-VSCode {
 
     $invocation = Start-Process @processParams
     $invocationErrors = Get-Content $stdErrTempFile -Raw -ErrorAction SilentlyContinue
-    $invocationErrors = $invocationErrors -replace '\n', '\n '
     $invocationOutput = Get-Content $stdOutTempFile -ErrorAction SilentlyContinue
     Remove-Item -Path $stdErrTempFile -ErrorAction Ignore
     Remove-Item -Path $stdOutTempFile -ErrorAction Ignore
 
-    if (![string]::IsNullOrWhiteSpace($invocationErrors)) { $invocationSuccess = $false }
-    if ($invocation.ExitCode) { $invocationSuccess = $false }
-    if (!$invocationSuccess) { throw [System.Configuration.ConfigurationException]::new("Executing '$VSCodeCLIPath $Command' failed. Command Output: '$invocationErrors'") }
+    if ($invocation.ExitCode -ne 0) {
+        $details = if ([string]::IsNullOrWhiteSpace($invocationErrors)) { $invocationOutput -join [System.Environment]::NewLine } else { $invocationErrors.Trim() }
+        throw [System.Configuration.ConfigurationException]::new("Executing '$VSCodeCLIPath $Command' failed with exit code $($invocation.ExitCode). Command Output: '$details'")
+    }
 
     return $invocationOutput
 }

--- a/resources/NpmDsc/NpmDsc.psm1
+++ b/resources/NpmDsc/NpmDsc.psm1
@@ -120,8 +120,9 @@ function GetNpmPath {
         } elseif (Test-Path $globalNpmCacheDir -ErrorAction SilentlyContinue) {
             return $globalNpmCacheDir
         } else {
-            $result = (Invoke-Npm -Command 'config list --json' | ConvertFrom-Json -ErrorAction SilentlyContinue).cache
-            if (Test-Path $result -ErrorAction SilentlyContinue) {
+            $cacheRoot = (Invoke-Npm -Command 'config list --json --logs-max=0' | ConvertFrom-Json -ErrorAction SilentlyContinue).cache
+            $result = if ($cacheRoot) { Join-Path $cacheRoot '_logs' } else { $null }
+            if ($result -and (Test-Path $result -ErrorAction SilentlyContinue)) {
                 return $result
             } else {
                 return $null
@@ -418,15 +419,19 @@ class NpmPackage {
 
     [string] WhatIf() {
         if ($this.Ensure -eq [Ensure]::Present) {
-            $whatIfState = Install-NpmPackage -PackageName $this.Name -Global $this.Global -Arguments '--dry-run'
-
             $out = @{
                 Name      = $this.Name
                 _metaData = @{
                     whatif = @()
                 }
             }
-            $out._metaData.whatif = $LASTEXITCODE -ne 0 ? (GetNpmWhatIfResponse) : ($whatIfState | Where-Object { $_.Trim() -ne '' }) # Removes empty lines from response
+
+            try {
+                $whatIfState = Install-NpmPackage -PackageName $this.Name -Global $this.Global -Arguments '--dry-run'
+                $out._metaData.whatif = $whatIfState | Where-Object { $_.Trim() -ne '' } # Removes empty lines from response
+            } catch {
+                $out._metaData.whatif = GetNpmWhatIfResponse
+            }
         } else {
             # Uninstall does not have --dry-run param
             $out = @{}

--- a/resources/NpmDsc/NpmDsc.psm1
+++ b/resources/NpmDsc/NpmDsc.psm1
@@ -128,7 +128,9 @@ function GetNpmPath {
         } elseif (Test-Path $globalNpmCacheDir -ErrorAction SilentlyContinue) {
             return $globalNpmCacheDir
         } else {
-            $cacheRoot = (Invoke-Npm -Command @('config', 'list', '--json', '--logs-max=0') | ConvertFrom-Json -ErrorAction SilentlyContinue).cache
+            # Call 'npm' directly rather than through Invoke-Npm: this is an error-reporting helper
+            # and Invoke-Npm's failure path calls back into GetNpmPath, which would recurse indefinitely.
+            $cacheRoot = (& npm config list --json --logs-max=0 2>$null | ConvertFrom-Json -ErrorAction SilentlyContinue).cache
             $result = if ($cacheRoot) { Join-Path $cacheRoot '_logs' } else { $null }
             if ($result -and (Test-Path $result -ErrorAction SilentlyContinue)) {
                 return $result


### PR DESCRIPTION
## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->
This PR improves reliability and error handling in the VSCode and Npm DSC PowerShell modules. It simplifies VSCode command execution by relying on exit codes with clearer error messages, strengthens NPM cache path resolution, and makes WhatIf() behavior more robust by handling dry-run failures through exceptions instead of $LASTEXITCODE.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-dsc/pull/292)