### PR TITLE
Add missing Issue-Bug label to Bug Report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yml
@@ -1,6 +1,7 @@
 name: '🐛 Bug Report'
 description: Report errors or unexpected behavior.
 type: Bug
+labels: ['Issue-Bug']
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## 📖 Description

Adds the missing `labels: ['Issue-Bug']` field to the `Bug_Report.yml` issue template, so new bug reports are automatically labeled — consistent with the repo's Documentation_Issue and Feature_Request templates, which already set their labels.

Found during an audit of issue template Issue Type consistency across `microsoft/winget-*` repos.

Created with GitHub Copilot's assistance.

## 🔗 References

Closes #305

## 🔍 Validation

Verified the `Issue-Bug` label already exists in this repo (gh label list).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-dsc/pull/306)